### PR TITLE
Bump ch.qos.logback:logback-classic from 1.2.12 to 1.3.12

### DIFF
--- a/pipeline.common/src/main/java/fiftyone/common/testhelpers/LogbackHelper.java
+++ b/pipeline.common/src/main/java/fiftyone/common/testhelpers/LogbackHelper.java
@@ -73,13 +73,9 @@ public class LogbackHelper {
         LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
 
         ContextInitializer ci = new ContextInitializer(loggerContext);
-        URL url = ci.findURLOfDefaultConfigurationFile(true);
 
         try {
-            JoranConfigurator configurator = new JoranConfigurator();
-            configurator.setContext(loggerContext);
-            loggerContext.reset();
-            configurator.doConfigure(url);
+            ci.autoConfig();
         } catch (JoranException je) {
             // StatusPrinter will handle this
         }

--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,8 @@
 
         <junit.version>4.13.2</junit.version>
         <junit.jupiter.version>5.8.2</junit.jupiter.version>
-        <slf4j-api.version>1.7.36</slf4j-api.version>
-        <logback-classic.version>1.2.12</logback-classic.version>
+        <slf4j-api.version>2.0.9</slf4j-api.version>
+        <logback-classic.version>1.3.12</logback-classic.version>
         <mockito-core.version>4.3.1</mockito-core.version>
         <org.json.version>20231013</org.json.version>
         <reflections8.version>0.11.7</reflections8.version>


### PR DESCRIPTION
- Bumps ch.qos.logback:logback-classic from 1.2.12 to 1.3.12
- Bump slf4j-api version to 2.0.9
- Replace deprecated logback's method usage in LogbackHelper