### PR TITLE
Use Azure Key Vault to sign JARs

### DIFF
--- a/.github/workflows/nightly-prs-to-main.yml
+++ b/.github/workflows/nightly-prs-to-main.yml
@@ -12,6 +12,7 @@ jobs:
     uses: 51Degrees/common-ci/.github/workflows/nightly-prs-to-main.yml@main
     with:
       repo-name: ${{ github.event.repository.name }}
+      org-name: ${{ github.event.repository.owner.login }}
     secrets:
       token: ${{ secrets.ACCESS_TOKEN }}
       TestResourceKey: ${{ secrets.SUPER_RESOURCE_KEY}}

--- a/.github/workflows/nightly-publish-main.yml
+++ b/.github/workflows/nightly-publish-main.yml
@@ -20,5 +20,8 @@ jobs:
       JavaGpgKeyPassphrase: ${{ secrets.JAVA_GPG_KEY_PASSPHRASE }}
       CodeSigningCert: ${{ secrets.CODE_SIGNING_CERT }}
       JavaPGP: ${{ secrets.JAVA_KEY_PGP_FILE }}
-      CodeSigningCertAlias: ${{ secrets.CODE_SIGNING_CERT_ALIAS }}
-      CodeSigningCertPassword: ${{ secrets.CODE_SIGNING_CERT_PASSWORD }}
+      CodeSigningKeyVaultUrl: ${{ secrets.CODE_SIGNING_KEY_VAULT_URL }}
+      CodeSigningKeyVaultClientId: ${{ secrets.CODE_SIGNING_KEY_VAULT_CLIENT_ID }}
+      CodeSigningKeyVaultTenantId: ${{ secrets.CODE_SIGNING_KEY_VAULT_TENANT_ID }}
+      CodeSigningKeyVaultClientSecret: ${{ secrets.CODE_SIGNING_KEY_VAULT_CLIENT_SECRET }}
+      CodeSigningKeyVaultCertificateName: ${{ secrets.CODE_SIGNING_KEY_VAULT_CERTIFICATE_NAME }}

--- a/.github/workflows/nightly-publish-main.yml
+++ b/.github/workflows/nightly-publish-main.yml
@@ -18,7 +18,6 @@ jobs:
       TestResourceKey: ${{ secrets.SUPER_RESOURCE_KEY}}
       MavenSettings: ${{ secrets.JAVA_STAGING_SETTINGS_BASE64 }}
       JavaGpgKeyPassphrase: ${{ secrets.JAVA_GPG_KEY_PASSPHRASE }}
-      CodeSigningCert: ${{ secrets.CODE_SIGNING_CERT }}
       JavaPGP: ${{ secrets.JAVA_KEY_PGP_FILE }}
       CodeSigningKeyVaultUrl: ${{ secrets.CODE_SIGNING_KEY_VAULT_URL }}
       CodeSigningKeyVaultClientId: ${{ secrets.CODE_SIGNING_KEY_VAULT_CLIENT_ID }}

--- a/.github/workflows/nightly-publish-main.yml
+++ b/.github/workflows/nightly-publish-main.yml
@@ -20,6 +20,7 @@ jobs:
       MavenSettings: ${{ secrets.JAVA_STAGING_SETTINGS_BASE64 }}
       JavaGpgKeyPassphrase: ${{ secrets.JAVA_GPG_KEY_PASSPHRASE }}
       JavaPGP: ${{ secrets.JAVA_KEY_PGP_FILE }}
+      CodeSigningKeyVaultName: ${{ secrets.CODE_SIGNING_KEY_VAULT_NAME }}
       CodeSigningKeyVaultUrl: ${{ secrets.CODE_SIGNING_KEY_VAULT_URL }}
       CodeSigningKeyVaultClientId: ${{ secrets.CODE_SIGNING_KEY_VAULT_CLIENT_ID }}
       CodeSigningKeyVaultTenantId: ${{ secrets.CODE_SIGNING_KEY_VAULT_TENANT_ID }}

--- a/.github/workflows/nightly-publish-main.yml
+++ b/.github/workflows/nightly-publish-main.yml
@@ -26,3 +26,4 @@ jobs:
       CodeSigningKeyVaultTenantId: ${{ secrets.CODE_SIGNING_KEY_VAULT_TENANT_ID }}
       CodeSigningKeyVaultClientSecret: ${{ secrets.CODE_SIGNING_KEY_VAULT_CLIENT_SECRET }}
       CodeSigningKeyVaultCertificateName: ${{ secrets.CODE_SIGNING_KEY_VAULT_CERTIFICATE_NAME }}
+      CodeSigningKeyVaultCertificateData: ${{ secrets.CODE_SIGNING_KEY_VAULT_CERTIFICATE_DATA }}

--- a/.github/workflows/nightly-publish-main.yml
+++ b/.github/workflows/nightly-publish-main.yml
@@ -12,6 +12,7 @@ jobs:
     uses: 51Degrees/common-ci/.github/workflows/nightly-publish-main.yml@main
     with:
       repo-name: ${{ github.event.repository.name }}
+      org-name: ${{ github.event.repository.owner.login }}
       build-platform: ubuntu-20.04
     secrets:
       token: ${{ secrets.ACCESS_TOKEN }}

--- a/ci/build-package.ps1
+++ b/ci/build-package.ps1
@@ -11,7 +11,20 @@ param(
 )
 
 
-./java/build-package.ps1 -RepoName $RepoName -ProjectDir $ProjectDir -Name $Name -Version $Version -ExtraArgs "-DskipNativeBuild=true" -JavaGpgKeyPassphrase $Keys['JavaGpgKeyPassphrase'] -CodeSigningCert $Keys['CodeSigningCert'] -JavaPGP $Keys['JavaPGP'] -CodeSigningCertAlias $Keys['CodeSigningCertAlias'] -CodeSigningCertPassword $Keys['CodeSigningCertPassword'] -MavenSettings $Keys['MavenSettings'] 
+./java/build-package.ps1 `
+    -RepoName $RepoName `
+    -ProjectDir $ProjectDir `
+    -Name $Name `
+    -Version $Version `
+    -ExtraArgs "-DskipNativeBuild=true" `
+    -JavaGpgKeyPassphrase $Keys['JavaGpgKeyPassphrase'] `
+    -JavaPGP $Keys['JavaPGP'] `
+    -CodeSigningKeyVaultUrl $Keys['CodeSigningKeyVaultUrl'] `
+    -CodeSigningKeyVaultClientId $Keys['CodeSigningKeyVaultClientId'] `
+    -CodeSigningKeyVaultTenantId $Keys['CodeSigningKeyVaultTenantId'] `
+    -CodeSigningKeyVaultClientSecret $Keys['CodeSigningKeyVaultClientSecret'] `
+    -CodeSigningKeyVaultCertificateName $Keys['CodeSigningKeyVaultCertificateName'] `
+    -MavenSettings $Keys['MavenSettings'] 
 
 
 exit $LASTEXITCODE

--- a/ci/build-package.ps1
+++ b/ci/build-package.ps1
@@ -19,6 +19,7 @@ param(
     -ExtraArgs "-DskipNativeBuild=true" `
     -JavaGpgKeyPassphrase $Keys['JavaGpgKeyPassphrase'] `
     -JavaPGP $Keys['JavaPGP'] `
+    -CodeSigningKeyVaultName: $Keys['-CodeSigningKeyVaultName'] `
     -CodeSigningKeyVaultUrl $Keys['CodeSigningKeyVaultUrl'] `
     -CodeSigningKeyVaultClientId $Keys['CodeSigningKeyVaultClientId'] `
     -CodeSigningKeyVaultTenantId $Keys['CodeSigningKeyVaultTenantId'] `

--- a/ci/build-package.ps1
+++ b/ci/build-package.ps1
@@ -25,6 +25,7 @@ param(
     -CodeSigningKeyVaultTenantId $Keys['CodeSigningKeyVaultTenantId'] `
     -CodeSigningKeyVaultClientSecret $Keys['CodeSigningKeyVaultClientSecret'] `
     -CodeSigningKeyVaultCertificateName $Keys['CodeSigningKeyVaultCertificateName'] `
+    -CodeSigningKeyVaultCertificateData $Keys['CodeSigningKeyVaultCertificateData'] `
     -MavenSettings $Keys['MavenSettings'] 
 
 

--- a/ci/build-package.ps1
+++ b/ci/build-package.ps1
@@ -19,7 +19,7 @@ param(
     -ExtraArgs "-DskipNativeBuild=true" `
     -JavaGpgKeyPassphrase $Keys['JavaGpgKeyPassphrase'] `
     -JavaPGP $Keys['JavaPGP'] `
-    -CodeSigningKeyVaultName: $Keys['-CodeSigningKeyVaultName'] `
+    -CodeSigningKeyVaultName: $Keys['CodeSigningKeyVaultName'] `
     -CodeSigningKeyVaultUrl $Keys['CodeSigningKeyVaultUrl'] `
     -CodeSigningKeyVaultClientId $Keys['CodeSigningKeyVaultClientId'] `
     -CodeSigningKeyVaultTenantId $Keys['CodeSigningKeyVaultTenantId'] `

--- a/pom.xml
+++ b/pom.xml
@@ -305,34 +305,30 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jarsigner-plugin</artifactId>
-                <version>${maven-jarsigner-plugin.version}</version>
+                <groupId>net.jsign</groupId>
+                <artifactId>jsign-maven-plugin</artifactId>
+                <version>6.0</version>
                 <executions>
-                <execution>
-                    <id>sign</id>
-                    <goals>
-                    <goal>sign</goal>
-                    </goals>
-                </execution>
+                    <execution>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skippackagesign}</skip>
+                            <fileset>
+                                <directory>target</directory>
+                                <includes>
+                                    <include>*.jar</include>
+                                </includes>
+                            </fileset>
+
+                            <storetype>AZUREKEYVAULT</storetype>
+                            <keystore>${keyvaultVaultName}</keystore>
+                            <storepass>${keyvaultAccessToken}</storepass>
+                            <alias>${keyvaultCertName}</alias>
+                        </configuration>
+                    </execution>
                 </executions>
-                <configuration>
-                    <skip>${skippackagesign}</skip>
-                    <keystore>NONE</keystore>
-                    <storetype>AzureKeyVault</storetype>
-                    <alias>${keyvaultCertName}</alias>
-                    <storepass/>
-                    <providerName>AzureKeyVault</providerName>
-                    <providerClass>com.azure.security.keyvault.jca.KeyVaultJcaProvider</providerClass>
-                    <arguments>
-                        <argument>-J--module-path="${keyvaultJcaJar}"</argument>
-                        <argument>-J--add-modules="com.azure.security.keyvault.jca"</argument>
-                        <argument>-J-Dazure.keyvault.uri=${keyvaultUrl}</argument>
-                        <argument>-J-Dazure.keyvault.tenant-id=${keyvaultTenant}</argument>
-                        <argument>-J-Dazure.keyvault.client-id=${keyvaultClientId}</argument>
-                        <argument>-J-Dazure.keyvault.client-secret=${keyvaultClientSecret}</argument>
-                    </arguments>
-                </configuration>
             </plugin>
            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -325,6 +325,7 @@
                     <providerClass>net.jsign.jca.JsignJcaProvider</providerClass>
                     <providerArg>${keyvaultVaultName}</providerArg>
                     <tsa>http://timestamp.globalsign.com/tsa/r6advanced1</tsa>
+                    <certchain>${keyvaultCertChain}</certchain>
                     <arguments>
                         <argument>-J-cp</argument>
                         <argument>-J${keyvaultJcaJar}</argument>

--- a/pom.xml
+++ b/pom.xml
@@ -318,11 +318,12 @@
                 </executions>
                 <configuration>
                     <skip>${skippackagesign}</skip>
-                    <keystore>${keyvaultVaultName}</keystore>
+                    <keystore>NONE</keystore>
                     <storetype>AZUREKEYVAULT</storetype>
                     <alias>${keyvaultCertName}</alias>
                     <storepass>${keyvaultAccessToken}</storepass>
                     <providerClass>net.jsign.jca.JsignJcaProvider</providerClass>
+                    <providerArg>${keyvaultVaultName}</providerArg>
                     <arguments>
                         <argument>-J-cp</argument>
                         <argument>-J${keyvaultJcaJar}</argument>

--- a/pom.xml
+++ b/pom.xml
@@ -324,6 +324,7 @@
                     <storepass>${keyvaultAccessToken}</storepass>
                     <providerClass>net.jsign.jca.JsignJcaProvider</providerClass>
                     <providerArg>${keyvaultVaultName}</providerArg>
+                    <tsa>http://timestamp.globalsign.com/tsa/r6advanced1</tsa>
                     <arguments>
                         <argument>-J-cp</argument>
                         <argument>-J${keyvaultJcaJar}</argument>

--- a/pom.xml
+++ b/pom.xml
@@ -324,8 +324,10 @@
                     <storepass>${keyvaultAccessToken}</storepass>
                     <providerClass>net.jsign.jca.JsignJcaProvider</providerClass>
                     <arguments>
-                        <argument>-J--class-path="${keyvaultJcaJar}"</argument>
-                        <argument>-J--add-modules="java.sql"</argument>
+                        <argument>-J-cp</argument>
+                        <argument>-J${keyvaultJcaJar}</argument>
+                        <argument>-J--add-modules</argument>
+                        <argument>-Jjava.sql</argument>
                     </arguments>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -318,10 +318,18 @@
                 </executions>
                 <configuration>
                     <skip>${skippackagesign}</skip>
-                    <keystore>${keystore}</keystore>
-                    <alias>${alias}</alias>
-                    <storepass>${keystorepass}</storepass>
-                    <keypass>${keypass}</keypass>
+                    <keystore>NONE</keystore>
+                    <storetype>AzureKeyVault</storetype>
+                    <alias>${keyvaultCertName}</alias>
+                    <storepass/>
+                    <providerName>AzureKeyVault</providerName>
+                    <providerClass>com.azure.security.keyvault.jca.KeyVaultJcaProvider</providerClass>
+                    <arguments>
+                        <argument>-J-Dazure.keyvault.uri=${keyvaultUrl}</argument>
+                        <argument>-J-Dazure.keyvault.tenant-id=${keyvaultTenant}</argument>
+                        <argument>-J-Dazure.keyvault.client-id=${keyvaultClientId}</argument>
+                        <argument>-J-Dazure.keyvault.client-secret=${keyvaultClientSecret}</argument>
+                    </arguments>
                 </configuration>
             </plugin>
            <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -325,6 +325,8 @@
                     <providerName>AzureKeyVault</providerName>
                     <providerClass>com.azure.security.keyvault.jca.KeyVaultJcaProvider</providerClass>
                     <arguments>
+                        <argument>-J--module-path="${keyvaultJcaJar}"</argument>
+                        <argument>-J--add-modules="com.azure.security.keyvault.jca"</argument>
                         <argument>-J-Dazure.keyvault.uri=${keyvaultUrl}</argument>
                         <argument>-J-Dazure.keyvault.tenant-id=${keyvaultTenant}</argument>
                         <argument>-J-Dazure.keyvault.client-id=${keyvaultClientId}</argument>


### PR DESCRIPTION
### Changes
- Add `org-name` to workflows.
- Use JSign as JCA Provider for signing JARs.
- Update the list of passed through secrets.

### Why
- https://github.com/postindustria-tech/51degrees-issues/issues/50

### Dependencies
- https://github.com/51Degrees/common-ci/pull/87