### PR TITLE
Clientside property service core allow origin

### DIFF
--- a/pipeline.web.packages/pipeline.web/src/main/java/fiftyone/pipeline/web/services/ClientsidePropertyServiceCore.java
+++ b/pipeline.web.packages/pipeline.web/src/main/java/fiftyone/pipeline/web/services/ClientsidePropertyServiceCore.java
@@ -270,6 +270,7 @@ public interface ClientsidePropertyServiceCore {
             response.setHeader("Cache-Control", stringJoin(cacheControl, ","));
             response.setHeader("Vary", stringJoin(headersAffectingJavaScript, ","));
             response.setHeader("ETag", Integer.toString(hash));
+            response.setHeader("Access-Control-Allow-Origin", "*");
         }
     }
 }

--- a/pipeline.web.packages/pipeline.web/src/main/java/fiftyone/pipeline/web/services/ClientsidePropertyServiceCore.java
+++ b/pipeline.web.packages/pipeline.web/src/main/java/fiftyone/pipeline/web/services/ClientsidePropertyServiceCore.java
@@ -239,13 +239,14 @@ public interface ClientsidePropertyServiceCore {
                     default:
                         break;
                 }
-                response.getWriter().write(content);
 
                 setHeaders(
                     response,
                     hash,
                     content == null ? 0 : content.length(),
                     contentType == ContentTypes.JavaScript ? "x-javascript" : "json");
+
+                response.getWriter().write(content);
             }
 
         }

--- a/pipeline.web.packages/pipeline.web/src/test/java/fiftyone/pipeline/web/ClientsidePropertyServiceTests.java
+++ b/pipeline.web.packages/pipeline.web/src/test/java/fiftyone/pipeline/web/ClientsidePropertyServiceTests.java
@@ -253,6 +253,8 @@ public class ClientsidePropertyServiceTests {
     else {
       verify(response, times(0)).setHeader(eq("ETag"), anyString());
     }
+
+    verify(response).setHeader(eq("Access-Control-Allow-Origin"), eq("*"));
   }
 
   @SuppressWarnings("rawtypes")


### PR DESCRIPTION
### Changes
- Add CORS header to `ClientsidePropertyServiceCore.Default`
- Add respective check to test.
- Write headers before content.