### PR TITLE
FEAT: The enable cookies option for `JavaScriptBuilderElement` is now configurable per-request.

### DIFF
--- a/pipeline.javascriptbuilder/src/main/java/fiftyone/pipeline/javascriptbuilder/Constants.java
+++ b/pipeline.javascriptbuilder/src/main/java/fiftyone/pipeline/javascriptbuilder/Constants.java
@@ -36,9 +36,17 @@ public class Constants {
              fiftyone.pipeline.core.Constants.EVIDENCE_SEPERATOR +
             EVIDENCE_OBJECT_NAME_SUFFIX;
 
+    /**
+     * The suffix used when the JavaScriptBuilderElement 'enable cookies'
+     * parameter is supplied as evidence.
+     */
     public static final String EVIDENCE_ENABLE_COOKIES_SUFFIX =
         "fod-js-enable-cookies";
 
+    /**
+     * The complete key to be used when the JavaScriptBuilderElement
+     * 'enable cookies' parameter is supplied as part of the query string.
+     */
     public static final String EVIDENCE_ENABLE_COOKIES =
         fiftyone.pipeline.core.Constants.EVIDENCE_QUERY_PREFIX +
             fiftyone.pipeline.core.Constants.EVIDENCE_SEPERATOR +

--- a/pipeline.javascriptbuilder/src/main/java/fiftyone/pipeline/javascriptbuilder/Constants.java
+++ b/pipeline.javascriptbuilder/src/main/java/fiftyone/pipeline/javascriptbuilder/Constants.java
@@ -35,7 +35,15 @@ public class Constants {
              fiftyone.pipeline.core.Constants.EVIDENCE_QUERY_PREFIX +
              fiftyone.pipeline.core.Constants.EVIDENCE_SEPERATOR +
             EVIDENCE_OBJECT_NAME_SUFFIX;
-    
+
+    public static final String EVIDENCE_ENABLE_COOKIES_SUFFIX =
+        "fod-js-enable-cookies";
+
+    public static final String EVIDENCE_ENABLE_COOKIES =
+        fiftyone.pipeline.core.Constants.EVIDENCE_QUERY_PREFIX +
+            fiftyone.pipeline.core.Constants.EVIDENCE_SEPERATOR +
+            EVIDENCE_ENABLE_COOKIES_SUFFIX;
+
     public static final String DEFAULT_PROTOCOL = "https";
     
     public static final String TEMPLATE = "/fiftyone/pipeline/javascriptbuilder/templates/JavaScriptResource.mustache";

--- a/pipeline.javascriptbuilder/src/main/java/fiftyone/pipeline/javascriptbuilder/flowelements/JavaScriptBuilderElement.java
+++ b/pipeline.javascriptbuilder/src/main/java/fiftyone/pipeline/javascriptbuilder/flowelements/JavaScriptBuilderElement.java
@@ -179,6 +179,7 @@ public class JavaScriptBuilderElement
                 Constants.EVIDENCE_HOST_KEY,
                 fiftyone.pipeline.core.Constants.EVIDENCE_PROTOCOL,
                 EVIDENCE_OBJECT_NAME,
+                EVIDENCE_ENABLE_COOKIES,
                 EVIDENCE_WEB_CONTEXT_ROOT),
                 String.CASE_INSENSITIVE_ORDER);
     }

--- a/pipeline.javascriptbuilder/src/main/java/fiftyone/pipeline/javascriptbuilder/flowelements/JavaScriptBuilderElement.java
+++ b/pipeline.javascriptbuilder/src/main/java/fiftyone/pipeline/javascriptbuilder/flowelements/JavaScriptBuilderElement.java
@@ -46,6 +46,7 @@ import java.util.*;
 import static fiftyone.pipeline.core.Constants.*;
 import static fiftyone.pipeline.engines.fiftyone.flowelements.Constants.EVIDENCE_SEQUENCE;
 import static fiftyone.pipeline.engines.fiftyone.flowelements.Constants.EVIDENCE_SESSIONID;
+import static fiftyone.pipeline.javascriptbuilder.Constants.EVIDENCE_ENABLE_COOKIES;
 import static fiftyone.pipeline.javascriptbuilder.Constants.EVIDENCE_OBJECT_NAME;
 
 //! [class]
@@ -402,6 +403,18 @@ public class JavaScriptBuilderElement
             objectName = res.getValue();
         }
 
+        boolean cookies;
+        // Try and get the requested enable cookies from evidence.
+        TryGetResult<String> cookieVal = data.tryGetEvidence(
+            EVIDENCE_ENABLE_COOKIES,
+            String.class);
+        if (cookieVal.hasValue() == false ||
+            cookieVal.getValue().isEmpty()) {
+            cookies = enableCookies;
+        } else {
+            cookies = Boolean.parseBoolean(cookieVal.getValue());
+        }
+
         boolean updateEnabled = url != null && url.isEmpty() == false;
 
         // This check won't be 100% fool-proof but it only needs to be
@@ -412,12 +425,12 @@ public class JavaScriptBuilderElement
         JavaScriptResource javaScriptObj = new JavaScriptResource(
             objectName,
             jsonObject,
-                sessionId,
-                sequence,
+            sessionId,
+            sequence,
             supportsPromises,
             url,
-                parameters,
-            enableCookies,    
+            parameters,
+            cookies,
             updateEnabled,
             hasDelayedProperties);
       

--- a/pipeline.javascriptbuilder/src/main/java/fiftyone/pipeline/javascriptbuilder/flowelements/JavaScriptBuilderElementBuilder.java
+++ b/pipeline.javascriptbuilder/src/main/java/fiftyone/pipeline/javascriptbuilder/flowelements/JavaScriptBuilderElementBuilder.java
@@ -156,7 +156,12 @@ public class JavaScriptBuilderElementBuilder {
     
     /**
      * Set whether the client JavaScript stores results of client side
-     * processing in cookies.
+     * processing in cookies. If set to false, the JavaScript will not populate
+     * any cookies, and will instead use session storage.
+     * <p>
+     * This can also be set per request, using the "query.fod-js-enable-cookies"
+     * evidence key. For more details on personal data policy, see
+     * http://51degrees.com/terms/client-services-privacy-policy/
      * <p>
      * Default is true
      * @param enableCookies should enable cookies?

--- a/pipeline.javascriptbuilder/src/test/java/fiftyone/pipeline/javascriptbuilder/CookieTests.java
+++ b/pipeline.javascriptbuilder/src/test/java/fiftyone/pipeline/javascriptbuilder/CookieTests.java
@@ -1,0 +1,159 @@
+package fiftyone.pipeline.javascriptbuilder;
+
+import fiftyone.common.testhelpers.TestLoggerFactory;
+import fiftyone.pipeline.core.data.*;
+import fiftyone.pipeline.core.flowelements.FlowElementBase;
+import fiftyone.pipeline.core.flowelements.Pipeline;
+import fiftyone.pipeline.core.flowelements.PipelineBuilder;
+import fiftyone.pipeline.engines.fiftyone.flowelements.SequenceElement;
+import fiftyone.pipeline.engines.fiftyone.flowelements.SequenceElementBuilder;
+import fiftyone.pipeline.javascriptbuilder.flowelements.JavaScriptBuilderElement;
+import fiftyone.pipeline.javascriptbuilder.flowelements.JavaScriptBuilderElementBuilder;
+import fiftyone.pipeline.jsonbuilder.flowelements.JsonBuilderElement;
+import fiftyone.pipeline.jsonbuilder.flowelements.JsonBuilderElementBuilder;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.slf4j.ILoggerFactory;
+import org.slf4j.Logger;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CookieTests {
+    private TestLoggerFactory loggerFactory;
+    public CookieTests() {
+        ILoggerFactory internalLogger = mock(ILoggerFactory.class);
+        when(internalLogger.getLogger(anyString())).thenReturn(mock(Logger.class));
+        loggerFactory = new TestLoggerFactory(internalLogger);
+    }
+
+    class CookieData extends ElementDataBase {
+
+        public CookieData(Logger logger, FlowData flowData) {
+            super(logger, flowData);
+        }
+    }
+
+    class CookieElement extends FlowElementBase<CookieData, ElementPropertyMetaDataDefault> {
+
+        public CookieElement(Logger logger) {
+            super(logger, null);
+        }
+
+        @Override
+        protected void processInternal(FlowData data) throws Exception {
+            CookieData result = new CookieData(this.logger, data);
+            result.put("javascript", "document.cookie =  \"some cookie value\"");
+            data.getOrAdd(getElementDataKey(), d -> result);
+        }
+
+        @Override
+        public String getElementDataKey() {
+            return "cookie";
+        }
+
+        @Override
+        public EvidenceKeyFilter getEvidenceKeyFilter() {
+            return new EvidenceKeyFilterWhitelist(Arrays.asList());
+        }
+
+        @Override
+        public List<ElementPropertyMetaDataDefault> getProperties() {
+            return Arrays.asList(
+                new ElementPropertyMetaDataDefault(
+                    "javascript",
+                    this,
+                    "category",
+                    String.class,
+                    true));
+        }
+
+        @Override
+        protected void managedResourcesCleanup() {
+
+        }
+
+        @Override
+        protected void unmanagedResourcesCleanup() {
+
+        }
+    }
+
+    /**
+     * Test various configurations for enabling cookies to verify
+     * that cookies are/aren't written for each configuration.
+     *
+     * The source JavaScript contains code to set a cookie. The JSBuilder
+     * element should replace this if the config says that cookies are not
+     * enabled.
+     * @param enableInConfig True if cookies are enabled in the element configuration.
+     * @param enableInEvidence True if cookies are enabled in the evidence.
+     * @param expectCookie True if the test should expect cookies to be enabled for this configuration.
+     */
+    @ParameterizedTest
+    @CsvSource(
+        {"false, false, false",
+        "true, false, false",
+        "false, true, true",
+        "true, true, true"})
+    public void TestJavaScriptCookies(
+        boolean enableInConfig,
+        boolean enableInEvidence,
+        boolean expectCookie) throws Exception {
+        // Arrange
+        CookieElement cookieElement = new CookieElement(loggerFactory.getLogger("cookie"));
+        SequenceElement sequenceElement = new SequenceElementBuilder(loggerFactory)
+            .build();
+        JsonBuilderElement jsonElement = new JsonBuilderElementBuilder(loggerFactory)
+            .build();
+        JavaScriptBuilderElement jsElement = new JavaScriptBuilderElementBuilder(loggerFactory)
+            .setEnableCookies(enableInConfig)
+            .build();
+        Pipeline pipeline = new PipelineBuilder(loggerFactory)
+            .addFlowElement(cookieElement)
+            .addFlowElement(sequenceElement)
+            .addFlowElement(jsonElement)
+            .addFlowElement(jsElement)
+            .build();
+
+        // Act
+        String javaScript = null;
+        try (FlowData flowData = pipeline.createFlowData())
+        {
+            flowData.addEvidence(
+                Constants.EVIDENCE_ENABLE_COOKIES,
+                Boolean.toString(enableInEvidence));
+            flowData.process();
+            javaScript = flowData.getFromElement(jsElement).getJavaScript();
+        }
+
+        // Assert
+        Pattern cookieRegex = Pattern.compile("document\\.cookie");
+        Matcher matcher = cookieRegex.matcher(javaScript);
+        long count = 0;
+        while (matcher.find()) {
+            count++;
+        }
+        if (expectCookie)
+        {
+            assertEquals(
+                2,
+                count,
+                "The original script to set cookies should not have been replaced.");
+        }
+        else
+        {
+            assertEquals(
+                1,
+                count,
+                "The original script to set cookies should have been replaced.");
+        }
+    }
+}


### PR DESCRIPTION
Adding the query parameter `fod-js-enable-cookies` will override the option supplied to the element at construction.

This PR addresses #53