### PR TITLE
Allow `LibLoader` to load "Debug" DLL

### DIFF
--- a/pipeline.engines.fiftyone/src/main/java/fiftyone/pipeline/engines/fiftyone/flowelements/interop/LibLoader.java
+++ b/pipeline.engines.fiftyone/src/main/java/fiftyone/pipeline/engines/fiftyone/flowelements/interop/LibLoader.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Optional;
 
 /**
  * Native library loader class used to load the correct compiled library for an
@@ -156,7 +157,9 @@ public class LibLoader {
         byte[] buffer = new byte[1024];
         int read;
         File temp = File.createTempFile(libName, "");
-        try (InputStream in = engineClass.getResourceAsStream("/" + libName)) {
+        try (InputStream in = Optional
+                .ofNullable(engineClass.getResourceAsStream("/" + libName))
+                .orElseGet(() -> engineClass.getResourceAsStream("/Debug/" + libName))) {
             if (in == null) {
                 throw new UnsatisfiedLinkError(String.format(
                     "Could not find the resource '%s'. Check the resource " +


### PR DESCRIPTION
### Changes

- Allow `LibLoader` to load "Debug" DLL
  - as a fallback option
    -  when "Release" DLL isn't present.

### Why

- Enable JNI debugging of [ip-intelligence-java](https://github.com/51Degrees/ip-intelligence-java) ?