### PR TITLE
fix: Allow FileSystemWatcher to work independently of AutoUpdate

### DIFF
--- a/pipeline.engines/src/main/java/fiftyone/pipeline/engines/configuration/DataFileConfigurationBuilderBase.java
+++ b/pipeline.engines/src/main/java/fiftyone/pipeline/engines/configuration/DataFileConfigurationBuilderBase.java
@@ -147,9 +147,12 @@ public abstract class DataFileConfigurationBuilderBase<
      * The {@link DataUpdateService} has the ability to watch a data file on
      * disk and automatically refresh the engine as soon as the file is updated.
      * This setting enables/disables that feature.
-     *
-     * The {@link #setAutoUpdate(boolean)} feature must also be enabled in order
-     * for the file system watcher to work.
+     * <p>
+     * This feature works independently of {@link #setAutoUpdate(boolean)}.
+     * You can enable file system watcher without enabling automatic updates
+     * if you want the engine to detect external file changes without polling
+     * for updates from the server.
+     * <p>
      * If the engine is built from a byte[] then this setting does nothing.
      * @param enabled  the cache configuration to use
      * @return this builder instance

--- a/pipeline.engines/src/main/java/fiftyone/pipeline/engines/flowelements/OnPremiseAspectEngineBuilderBase.java
+++ b/pipeline.engines/src/main/java/fiftyone/pipeline/engines/flowelements/OnPremiseAspectEngineBuilderBase.java
@@ -187,15 +187,18 @@ public abstract class OnPremiseAspectEngineBuilderBase<
             dataFile.setConfiguration(dataFileConfig);
             dataFile.setTempDataDirPath(tempDir);
 
-            if (dataFileConfig.getAutomaticUpdatesEnabled()) {
+            if (dataFileConfig.getAutomaticUpdatesEnabled() ||
+                dataFileConfig.getFileSystemWatcherEnabled()) {
                 if (dataUpdateService == null) {
                     throw new RuntimeException(
-                        "Auto update enabled by data update service does not exist. " +
-                            "This can be corrected by passing an DataUpdateService " +
+                        "Data update service is required but does not exist. " +
+                            "The data update service is needed when automatic updates " +
+                            "or file system watcher is enabled. " +
+                            "This can be corrected by passing a DataUpdateService " +
                             "instance to the engine builder constructor. " +
                             "If building from configuration, this can be corrected " +
-                            "by adding an DataUpdateService instance to the " +
-                            "the pipeline builder via addService() method.");
+                            "by adding a DataUpdateService instance to the " +
+                            "pipeline builder via addService() method.");
                 }
                 dataUpdateService.registerDataFile(dataFile);
             }

--- a/pipeline.engines/src/main/java/fiftyone/pipeline/engines/flowelements/SingleFileAspectEngineBuilderBase.java
+++ b/pipeline.engines/src/main/java/fiftyone/pipeline/engines/flowelements/SingleFileAspectEngineBuilderBase.java
@@ -216,8 +216,10 @@ public abstract class SingleFileAspectEngineBuilderBase<
      * disk and automatically refresh the engine as soon as the file is updated.
      * This setting enables/disables that feature.
      * <p>
-     * The {@link #setAutoUpdate(boolean)} feature must also be enabled in order
-     * for the file system watcher to work.
+     * This feature works independently of {@link #setAutoUpdate(boolean)}.
+     * You can enable file system watcher without enabling automatic updates
+     * if you want the engine to detect external file changes without polling
+     * for updates from the server.
      * <p>
      * If the engine is built from a byte[] then this setting does nothing.
      * <p>

--- a/pipeline.engines/src/test/java/fiftyone/pipeline/engines/flowelements/OnPremiseAspectEngineBuilderBaseTest.java
+++ b/pipeline.engines/src/test/java/fiftyone/pipeline/engines/flowelements/OnPremiseAspectEngineBuilderBaseTest.java
@@ -40,6 +40,12 @@ import java.util.Set;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+
+import fiftyone.pipeline.engines.configuration.DataFileConfiguration;
+import fiftyone.pipeline.engines.configuration.DataFileConfigurationDefault;
+import fiftyone.pipeline.engines.data.AspectEngineDataFile;
+import fiftyone.pipeline.engines.services.DataUpdateService;
 
 @SuppressWarnings("rawtypes")
 public class OnPremiseAspectEngineBuilderBaseTest {
@@ -48,12 +54,12 @@ public class OnPremiseAspectEngineBuilderBaseTest {
 
     @Before
     public void Init() {
-        aspectEngineBuilder = createEngineBuilderBase();
+        aspectEngineBuilder = createEngineBuilderBase(null);
         deleteTempDir();
     }
 
-    private OnPremiseAspectEngineBuilderBase createEngineBuilderBase() {
-        return new OnPremiseAspectEngineBuilderBase() {
+    private OnPremiseAspectEngineBuilderBase createEngineBuilderBase(DataUpdateService dataUpdateService) {
+        return new OnPremiseAspectEngineBuilderBase(null, dataUpdateService) {
             @Override
             public OnPremiseAspectEngineBuilderBase setPerformanceProfile(Constants.PerformanceProfiles profile) {
                 return null;
@@ -130,5 +136,19 @@ public class OnPremiseAspectEngineBuilderBaseTest {
         assertTrue(tempDir.canRead());
         assertTrue(tempDir.canWrite());
         assertTrue(tempDir.canExecute());
+    }
+
+    @Test
+    public void testRegisterWithFileSystemWatcherOnly() {
+        DataUpdateService dataUpdateService = mock(DataUpdateService.class);
+        OnPremiseAspectEngineBuilderBase builder = createEngineBuilderBase(dataUpdateService);
+        DataFileConfiguration config = new DataFileConfigurationDefault();
+        config.setAutomaticUpdatesEnabled(false);
+        config.setFileSystemWatcherEnabled(true);
+        config.setIdentifier("test");
+        builder.addDataFile(config);
+        builder.preCreateEngine();
+
+        verify(dataUpdateService, times(1)).registerDataFile(any(AspectEngineDataFile.class));
     }
 }


### PR DESCRIPTION
Previously, FileSystemWatcher would not work when AutoUpdate was disabled because registerDataFile() was only called when AutoUpdate=true.

The DataUpdateServiceDefault already handles both features independently:
- AutoUpdate timer is only created if getAutomaticUpdatesEnabled() is true
- FileSystemWatcher is only created if getFileSystemWatcherEnabled() is true

This change updates the condition to register the data file when EITHER feature is enabled, allowing users to use FileSystemWatcher without enabling automatic updates from the server.

Changes:
- OnPremiseAspectEngineBuilderBase: Changed condition to register when AutoUpdate OR FileSystemWatcher is enabled
- Updated error message to reflect both features
- Updated JavaDoc in SingleFileAspectEngineBuilderBase and DataFileConfigurationBuilderBase to clarify independent operation