### PR TITLE
Decorate `GZIPInputStream` with `DigestInputStream`, not the other way around.

### DIFF
--- a/pipeline.engines/src/main/java/fiftyone/pipeline/engines/services/DataUpdateServiceDefault.java
+++ b/pipeline.engines/src/main/java/fiftyone/pipeline/engines/services/DataUpdateServiceDefault.java
@@ -620,6 +620,10 @@ public class DataUpdateServiceDefault implements DataUpdateService {
                         logger.debug("HTTP Status is OK");
                         // wrap input stream in a buffered stream
                         InputStream is = new BufferedInputStream(connection.getInputStream());
+                        // decompress, if necessary
+                        if (dataFile.getConfiguration().getDecompressContent()) {
+                            is = new GZIPInputStream(is);
+                        }
                         // if checking md5 wrap in a DigestStream
                         MessageDigest md = null;
                         if (dataFile.getConfiguration().getVerifyMd5()) {
@@ -634,10 +638,6 @@ public class DataUpdateServiceDefault implements DataUpdateService {
                                 return AutoUpdateStatus.AUTO_UPDATE_ERR_MD5_VALIDATION_FAILED;
                             }
                             is = new DigestInputStream(is, md);
-                        }
-                        // decompress, if necessary
-                        if (dataFile.getConfiguration().getDecompressContent()) {
-                            is = new GZIPInputStream(is);
                         }
                         // copy resulting stream to destination
                         if (Objects.nonNull(tempFile.getPath())) {


### PR DESCRIPTION
### Changes

- Decorate `GZIPInputStream` with `DigestInputStream`.
  - not the other way around.

### Why

- https://github.com/51Degrees/pipeline-java/blob/c7906dda8fd75456824ed034c352cd6d2180d069/pipeline.engines/src/main/java/fiftyone/pipeline/engines/services/DataUpdateServiceDefault.java#L636-L640
  - `DigestInputStream` receives uncompressed data.
- https://github.com/51Degrees/pipeline-dotnet/blob/2b90bb0a37f72d5edb71a60a8e56b3827a299578/FiftyOne.Pipeline.Engines/Services/DataUpdateService.cs#L1055
  - .NET counterpart verifies still compressed bytes (as downloaded).
- https://github.com/51Degrees/device-detection-java/actions/runs/26076192848/job/76667759521#step:5:5642
  - Update on start up failed and there is no existing data file. Status was AUTO_UPDATE_ERR_MD5_VALIDATION_FAILED