### PR TITLE
Add UTM parameters to 51degrees.com links

### DIFF
--- a/.github/workflows/utm-link-lint.yml
+++ b/.github/workflows/utm-link-lint.yml
@@ -1,0 +1,25 @@
+name: UTM link lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  utm-link-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout common-ci
+        uses: actions/checkout@v4
+        with:
+          repository: 51Degrees/common-ci
+          path: utm-lint-common-ci
+
+      - name: Lint 51degrees.com links
+        shell: pwsh
+        run: ./utm-lint-common-ci/scripts/utm-lint.ps1 -RepoRoot .

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # 51Degrees Pipeline
 
-![51Degrees](https://51degrees.com/DesktopModules/FiftyOne/Distributor/Logo.ashx?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=node-open-source "Data rewards the curious") **Java Pipeline**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=pipeline-java&utm_content=readme.md&utm_term=top "Data rewards the curious") **Java Pipeline**
 
-[Developer Documentation](https://51degrees.com/pipeline-java/index.html?utm_source=github&utm_medium=repository&utm_content=documentation&utm_campaign=java-open-source "developer documentation")
+[Developer Documentation](https://51degrees.com/pipeline-java/index.html?utm_source=github&utm_medium=readme&utm_campaign=pipeline-java&utm_content=readme.md&utm_term=top "developer documentation")
 
 ## Introduction
 This repository contains all the projects required to build the Java implementation of the 51Degrees Pipeline API.
@@ -12,11 +12,11 @@ is also available on GitHub and is recommended reading if you wish to understand
 the concepts and design of this API.
 
 Reference documentation for the Java implementation can be found on the
-[Java API documentation](https://51degrees.com/pipeline-java/index.html) page.
+[Java API documentation](https://51degrees.com/pipeline-java/index.html?utm_source=github&utm_medium=readme&utm_campaign=pipeline-java&utm_content=readme.md&utm_term=introduction) page.
 
 ## Pre-requisites
 
-The [tested versions](https://51degrees.com/documentation/_info__tested_versions.html) page shows 
+The [tested versions](https://51degrees.com/documentation/_info__tested_versions.html?utm_source=github&utm_medium=readme&utm_campaign=pipeline-java&utm_content=readme.md&utm_term=pre-requisites) page shows 
 the JDK versions that we currently test against. The software may run fine against other versions, 
 but additional caution should be applied.
 
@@ -45,7 +45,7 @@ There are several examples available in the `pipeline.developer-examples` folder
 how to make use of the Pipeline API in isolation. These are described in the table below.
 If you want examples that demonstrate how to use 51Degrees products such as device detection, 
 then these are available in the corresponding [repository](https://github.com/51Degrees/device-detection-java) 
-and on our [website](http://51degrees.com/documentation/_examples__device_detection__index.html).
+and on our [website](https://51degrees.com/documentation/_examples__device_detection__index.html?utm_source=github&utm_medium=readme&utm_campaign=pipeline-java&utm_content=readme.md&utm_term=examples).
 
 | Example                                            | Description |
 |----------------------------------------------------|-------------|

--- a/pipeline.caching/pom.xml
+++ b/pipeline.caching/pom.xml
@@ -33,7 +33,7 @@
 
     <artifactId>pipeline.caching</artifactId>
     <name>51Degrees :: Pipeline :: Caching</name>
-    <url>https:51degrees.com</url>
+    <url>https://51degrees.com?utm_source=maven&amp;utm_medium=package&amp;utm_campaign=pipeline-java&amp;utm_content=pipeline.caching-pom.xml&amp;utm_term=url</url>
 
     <dependencies>
         <!-- Hidden dependency on MavenTestRunner -->

--- a/pipeline.cloudrequestengine/pom.xml
+++ b/pipeline.cloudrequestengine/pom.xml
@@ -34,7 +34,7 @@
     <artifactId>pipeline.cloudrequestengine</artifactId>
     <name>51Degrees :: Pipeline :: Cloud Request Engine</name>
     <description>Cloud request engine for the 51Degrees Pipeline API</description>
-    <url>https:51degrees.com</url>
+    <url>https://51degrees.com?utm_source=maven&amp;utm_medium=package&amp;utm_campaign=pipeline-java&amp;utm_content=pipeline.cloudrequestengine-pom.xml&amp;utm_term=url</url>
 
     <dependencies>
 

--- a/pipeline.cloudrequestengine/src/main/java/fiftyone/pipeline/cloudrequestengine/Constants.java
+++ b/pipeline.cloudrequestengine/src/main/java/fiftyone/pipeline/cloudrequestengine/Constants.java
@@ -46,7 +46,7 @@ public class Constants {
                 + "because your resource key does not include access to any "
                 + "properties under '%s'. For more details on resource keys, "
                 + "see our explainer: "
-                + "https://51degrees.com/documentation/_info__resource_keys.html";
+                + "https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=comment&utm_campaign=pipeline-java&utm_content=pipeline.cloudrequestengine-src-main-java-fiftyone-pipeline-cloudrequestengine-constants.java&utm_term=exceptionfailedtoloadproperties";
         
         public static final String ProcessCloudEngineNotImplemented = 
                   "This method should be overridden in the class derived from "

--- a/pipeline.cloudrequestengine/src/main/java/fiftyone/pipeline/cloudrequestengine/flowelements/CloudRequestEngineBuilder.java
+++ b/pipeline.cloudrequestengine/src/main/java/fiftyone/pipeline/cloudrequestengine/flowelements/CloudRequestEngineBuilder.java
@@ -79,7 +79,7 @@ public class CloudRequestEngineBuilder extends
             throw new PipelineConfigurationException("A resource key is " +
                     "required to access the cloud server. Please use the " +
                     "'setResourceKey(String) method to supply your resource " +
-                    "key obtained from https://configure.51degrees.com");
+                    "key obtained from https://configure.51degrees.com?utm_source=code&utm_medium=comment&utm_campaign=pipeline-java&utm_content=pipeline.cloudrequestengine-src-main-java-fiftyone-pipeline-cloudrequestengine-flowelements-cloudrequestenginebuilder.java&utm_term=resource-key-required");
         }
 
         /*

--- a/pipeline.common/pom.xml
+++ b/pipeline.common/pom.xml
@@ -33,7 +33,7 @@
 
     <artifactId>pipeline.common</artifactId>
     <name>51Degrees :: Pipeline :: Common</name>
-    <url>https:51degrees.com</url>
+    <url>https://51degrees.com?utm_source=maven&amp;utm_medium=package&amp;utm_campaign=pipeline-java&amp;utm_content=pipeline.common-pom.xml&amp;utm_term=url</url>
 
     <dependencies>
         <dependency>

--- a/pipeline.core/pom.xml
+++ b/pipeline.core/pom.xml
@@ -38,7 +38,7 @@
 
     <name>51Degrees :: Pipeline :: Core</name>
     <description>Core library for the 51Degrees Pipeline API</description>
-    <url>https:51degrees.com</url>
+    <url>https://51degrees.com?utm_source=maven&amp;utm_medium=package&amp;utm_campaign=pipeline-java&amp;utm_content=pipeline.core-pom.xml&amp;utm_term=url</url>
 
     <dependencies>
         <dependency>

--- a/pipeline.developer-examples/pipeline.developer-examples.clientside-element-mvc/pom.xml
+++ b/pipeline.developer-examples/pipeline.developer-examples.clientside-element-mvc/pom.xml
@@ -34,7 +34,7 @@
 
     <artifactId>pipeline.developerexamples.clientsideelement.mvc</artifactId>
     <name>51Degrees :: Pipeline :: Developer Examples :: Client-Side Element :: MVC</name>
-    <url>https:51degrees.com</url>
+    <url>https://51degrees.com?utm_source=maven&amp;utm_medium=package&amp;utm_campaign=pipeline-java&amp;utm_content=pipeline.developer-examples-pipeline.developer-examples.clientside-element-mvc-pom.xml&amp;utm_term=url</url>
 
     <dependencies>
         <dependency>

--- a/pipeline.developer-examples/pipeline.developer-examples.clientside-element/pom.xml
+++ b/pipeline.developer-examples/pipeline.developer-examples.clientside-element/pom.xml
@@ -33,7 +33,7 @@
 
     <artifactId>pipeline.developerexamples.clientsideelement</artifactId>
     <name>51Degrees :: Pipeline :: Developer Examples :: Client-Side Element</name>
-    <url>https:51degrees.com</url>
+    <url>https://51degrees.com?utm_source=maven&amp;utm_medium=package&amp;utm_campaign=pipeline-java&amp;utm_content=pipeline.developer-examples-pipeline.developer-examples.clientside-element-pom.xml&amp;utm_term=url</url>
 
     <dependencies>
         <dependency>

--- a/pipeline.developer-examples/pipeline.developer-examples.cloud-engine/pom.xml
+++ b/pipeline.developer-examples/pipeline.developer-examples.cloud-engine/pom.xml
@@ -33,7 +33,7 @@
 
     <artifactId>pipeline.developerexamples.cloudengine</artifactId>
     <name>51Degrees :: Pipeline :: Developer Examples :: Cloud Engine</name>
-    <url>https:51degrees.com</url>
+    <url>https://51degrees.com?utm_source=maven&amp;utm_medium=package&amp;utm_campaign=pipeline-java&amp;utm_content=pipeline.developer-examples-pipeline.developer-examples.cloud-engine-pom.xml&amp;utm_term=url</url>
 
     <dependencies>
         <dependency>

--- a/pipeline.developer-examples/pipeline.developer-examples.flowelement/pom.xml
+++ b/pipeline.developer-examples/pipeline.developer-examples.flowelement/pom.xml
@@ -33,7 +33,7 @@
 
     <artifactId>pipeline.developerexamples.flowelement</artifactId>
     <name>51Degrees :: Pipeline :: Developer Examples :: Flow Element</name>
-    <url>https:51degrees.com</url>
+    <url>https://51degrees.com?utm_source=maven&amp;utm_medium=package&amp;utm_campaign=pipeline-java&amp;utm_content=pipeline.developer-examples-pipeline.developer-examples.flowelement-pom.xml&amp;utm_term=url</url>
 
     <dependencies>
         <dependency>

--- a/pipeline.developer-examples/pipeline.developer-examples.onpremise-engine/pom.xml
+++ b/pipeline.developer-examples/pipeline.developer-examples.onpremise-engine/pom.xml
@@ -33,7 +33,7 @@
 
     <artifactId>pipeline.developerexamples.onpremiseengine</artifactId>
     <name>51Degrees :: Pipeline :: Developer Examples :: On-Premise Aspect Engine</name>
-    <url>https:51degrees.com</url>
+    <url>https://51degrees.com?utm_source=maven&amp;utm_medium=package&amp;utm_campaign=pipeline-java&amp;utm_content=pipeline.developer-examples-pipeline.developer-examples.onpremise-engine-pom.xml&amp;utm_term=url</url>
 
     <dependencies>
         <dependency>

--- a/pipeline.developer-examples/pipeline.developer-examples.usage-sharing/pom.xml
+++ b/pipeline.developer-examples/pipeline.developer-examples.usage-sharing/pom.xml
@@ -33,7 +33,7 @@
 
     <artifactId>pipeline.developerexamples.usagesharing</artifactId>
     <name>51Degrees :: Pipeline :: Developer Examples :: Usage Sharing</name>
-    <url>https:51degrees.com</url>
+    <url>https://51degrees.com?utm_source=maven&amp;utm_medium=package&amp;utm_campaign=pipeline-java&amp;utm_content=pipeline.developer-examples-pipeline.developer-examples.usage-sharing-pom.xml&amp;utm_term=url</url>
 
     <dependencies>
         <dependency>

--- a/pipeline.engines.fiftyone/pom.xml
+++ b/pipeline.engines.fiftyone/pom.xml
@@ -34,7 +34,7 @@
     <artifactId>pipeline.engines.fiftyone</artifactId>
     <name>51Degrees :: Pipeline :: FiftyOne</name>
     <description>Shared base functions for implementing 51Degrees engines for the 51Degrees Pipeline API</description>
-    <url>https:51degrees.com</url>
+    <url>https://51degrees.com?utm_source=maven&amp;utm_medium=package&amp;utm_campaign=pipeline-java&amp;utm_content=pipeline.engines.fiftyone-pom.xml&amp;utm_term=url</url>
 
     <dependencies>
         <dependency>

--- a/pipeline.engines/pom.xml
+++ b/pipeline.engines/pom.xml
@@ -34,7 +34,7 @@
 
     <name>51Degrees :: Pipeline :: Engines</name>
     <description>Shared base functionality for implementing engines for the 51Degrees Pipeline API</description>
-    <url>https:51degrees.com</url>
+    <url>https://51degrees.com?utm_source=maven&amp;utm_medium=package&amp;utm_campaign=pipeline-java&amp;utm_content=pipeline.engines-pom.xml&amp;utm_term=url</url>
 
     <dependencies>
         <dependency>

--- a/pipeline.engines/src/main/java/fiftyone/pipeline/engines/Constants.java
+++ b/pipeline.engines/src/main/java/fiftyone/pipeline/engines/Constants.java
@@ -56,13 +56,13 @@ public class Constants {
             "This is because your resource key does not include access to " +
             "any properties under '%s'. For more details on resource keys, " +
             "see our explainer: " +
-            "https://51degrees.com/documentation/_info__resource_keys.html";
+            "https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=comment&utm_campaign=pipeline-java&utm_content=pipeline.engines-src-main-java-fiftyone-pipeline-engines-constants.java&utm_term=product_not_in_cloud_resource";
         public static final String PROPERTY_NOT_IN_CLOUD_RESOURCE =
             "This is because your resource key does not include access to " +
             "this property. Properties that are included for this key under " +
             "'%s' are %s. For more details on resource keys, see our " +
             "explainer: " +
-            "https://51degrees.com/documentation/_info__resource_keys.html";
+            "https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=comment&utm_campaign=pipeline-java&utm_content=pipeline.engines-src-main-java-fiftyone-pipeline-engines-constants.java&utm_term=property_not_in_cloud_resource";
         public static final String UNKNOWN =
             "The reason for this is unknown. Please check that the aspect " +
             "and property name are correct.";

--- a/pipeline.engines/src/main/java/fiftyone/pipeline/engines/flowelements/SingleFileAspectEngineBuilderBase.java
+++ b/pipeline.engines/src/main/java/fiftyone/pipeline/engines/flowelements/SingleFileAspectEngineBuilderBase.java
@@ -351,7 +351,7 @@ public abstract class SingleFileAspectEngineBuilderBase<
      * Default is no license key.
      * @param key the license key to use when checking for updates to the data
      *            file. A license key can be obtained from the
-     *            <a href="https://51degrees.com/pricing">51Degrees website</a>.
+     *            <a href="https://51degrees.com/pricing?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=pipeline-java&amp;utm_content=pipeline.engines-src-main-java-fiftyone-pipeline-engines-flowelements-singlefileaspectenginebuilderbase.java&amp;utm_term=setdataupdatelicensekey">51Degrees website</a>.
      *            If you have no license key then this parameter can be set to
      *            null, but doing so will disable automatic updates.
      * @return this builder

--- a/pipeline.javascriptbuilder/pom.xml
+++ b/pipeline.javascriptbuilder/pom.xml
@@ -35,7 +35,7 @@
     <packaging>jar</packaging>
 
     <name>51Degrees :: Pipeline :: Java Script Builder</name>
-    <url>https:51degrees.com</url>
+    <url>https://51degrees.com?utm_source=maven&amp;utm_medium=package&amp;utm_campaign=pipeline-java&amp;utm_content=pipeline.javascriptbuilder-pom.xml&amp;utm_term=url</url>
 
     <dependencies>
         <dependency>

--- a/pipeline.javascriptbuilder/src/main/java/fiftyone/pipeline/javascriptbuilder/flowelements/JavaScriptBuilderElementBuilder.java
+++ b/pipeline.javascriptbuilder/src/main/java/fiftyone/pipeline/javascriptbuilder/flowelements/JavaScriptBuilderElementBuilder.java
@@ -161,7 +161,7 @@ public class JavaScriptBuilderElementBuilder {
      * <p>
      * This can also be set per request, using the "query.fod-js-enable-cookies"
      * evidence key. For more details on personal data policy, see
-     * http://51degrees.com/terms/client-services-privacy-policy/
+     * https://51degrees.com/terms/client-services-privacy-policy/?utm_source=code&utm_medium=comment&utm_campaign=pipeline-java&utm_content=pipeline.javascriptbuilder-src-main-java-fiftyone-pipeline-javascriptbuilder-flowelements-javascriptbuilderelementbuilder.java&utm_term=setenablecookies
      * <p>
      * Default is true
      * @param enableCookies should enable cookies?

--- a/pipeline.jsonbuilder/pom.xml
+++ b/pipeline.jsonbuilder/pom.xml
@@ -32,7 +32,7 @@
     <packaging>jar</packaging>
     
     <name>51Degrees :: Pipeline :: JSON Builder</name>
-    <url>https:51degrees.com</url>
+    <url>https://51degrees.com?utm_source=maven&amp;utm_medium=package&amp;utm_campaign=pipeline-java&amp;utm_content=pipeline.jsonbuilder-pom.xml&amp;utm_term=url</url>
 
     <dependencies>
         <dependency>

--- a/pipeline.web.packages/pipeline.web.mvc/pom.xml
+++ b/pipeline.web.packages/pipeline.web.mvc/pom.xml
@@ -33,7 +33,7 @@
 
     <artifactId>pipeline.web.mvc</artifactId>
     <name>51Degrees :: Pipeline :: Web :: MVC</name>
-    <url>https:51degrees.com</url>
+    <url>https://51degrees.com?utm_source=maven&amp;utm_medium=package&amp;utm_campaign=pipeline-java&amp;utm_content=pipeline.web.packages-pipeline.web.mvc-pom.xml&amp;utm_term=url</url>
 
     <dependencies>
         <dependency>

--- a/pipeline.web.packages/pipeline.web.shared/pom.xml
+++ b/pipeline.web.packages/pipeline.web.shared/pom.xml
@@ -33,7 +33,7 @@
     <artifactId>pipeline.web.shared</artifactId>
 
     <name>51Degrees :: Pipeline :: Web :: Shared</name>
-    <url>https:51degrees.com</url>
+    <url>https://51degrees.com?utm_source=maven&amp;utm_medium=package&amp;utm_campaign=pipeline-java&amp;utm_content=pipeline.web.packages-pipeline.web.shared-pom.xml&amp;utm_term=url</url>
 
     <dependencies>
         <dependency>

--- a/pipeline.web.packages/pipeline.web/pom.xml
+++ b/pipeline.web.packages/pipeline.web/pom.xml
@@ -32,7 +32,7 @@
 
     <artifactId>pipeline.web</artifactId>
     <name>51Degrees :: Pipeline :: Web</name>
-    <url>https:51degrees.com</url>
+    <url>https://51degrees.com?utm_source=maven&amp;utm_medium=package&amp;utm_campaign=pipeline-java&amp;utm_content=pipeline.web.packages-pipeline.web-pom.xml&amp;utm_term=url</url>
 
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -31,12 +31,12 @@
     <packaging>pom</packaging>
 
     <name>51Degrees :: Pipeline</name>
-    <url>https://51degrees.com</url>
+    <url>https://51degrees.com?utm_source=maven&amp;utm_medium=package&amp;utm_campaign=pipeline-java&amp;utm_content=pom.xml&amp;utm_term=url</url>
     <description>The 51Degrees Pipeline API provides architecture for consuming real-time digital data services.</description>
 
     <organization>
         <name>51Degrees</name>
-        <url>51degrees.com</url>
+        <url>https://51degrees.com?utm_source=maven&amp;utm_medium=package&amp;utm_campaign=pipeline-java&amp;utm_content=pom.xml&amp;utm_term=url-2</url>
     </organization>
     <developers>
         <developer>


### PR DESCRIPTION
Apply the standard UTM vocabulary to navigational 51degrees.com and configure.51degrees.com links so the Content Team can trace traffic to its exact source.

## What changed

- `utm_source` = `github` for the README, `code` for Java comments/javadoc and user-visible runtime messages, `maven` for `pom.xml` `<url>` package metadata.
- `utm_medium` = `readme` for the README, `comment` for library source, `package` for `pom.xml`.
- `utm_campaign` = `pipeline-java`.
- `utm_content` = file path slug.
- `utm_term` = location within the file. Runtime message links take a message identifier (`resource-key-required`, `product_not_in_cloud_resource`, `property_not_in_cloud_resource`, `exceptionfailedtoloadproperties`); everything else takes the nearest heading or enclosing member.
- Normalised `http` to `https`, fixed the malformed `https:51degrees.com` package URLs to `https://51degrees.com`, and replaced the retired `Logo.ashx` README logo with `/img/logo.png`.

## Not changed

- `scm`/`developerConnection` git URL and the `engineering@51degrees.com` email in the root `pom.xml`.
- Functional and machine-fetched endpoints: `cloud.51degrees.com`, `distributor.51degrees.com`, `devices-v4.51degrees.com`, and the `/starsign/` example endpoint.
- `support@51degrees.com` addresses in `LibLoader.java`.
- Test fixtures and test resources (`options-test.xml`, `*Tests*.java`).
- The `javascript-templates` submodule (empty on this checkout).

A `utm-link-lint` GitHub Actions workflow is added in a separate commit to keep these links conformant going forward.
