### PR TITLE
FIX: Address Java compiler warnings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.compile.nullAnalysis.mode": "automatic"
+}

--- a/pipeline.caching/src/main/java/fiftyone/caching/LruLoadingCache.java
+++ b/pipeline.caching/src/main/java/fiftyone/caching/LruLoadingCache.java
@@ -71,7 +71,7 @@ public class LruLoadingCache<K, V>
      */
     LruLoadingCache(int cacheSize, ValueLoader<K, V> loader, int concurrency) {
         super(cacheSize, concurrency, false);
-        setCacheLoader(loader);
+        this.loader = loader;
     }
 
     /**

--- a/pipeline.cloudrequestengine/src/main/java/fiftyone/pipeline/cloudrequestengine/CloudRequestException.java
+++ b/pipeline.cloudrequestengine/src/main/java/fiftyone/pipeline/cloudrequestengine/CloudRequestException.java
@@ -38,7 +38,7 @@ public class CloudRequestException extends PipelineDataException {
     private static final long serialVersionUID = 2110016714691972118L;
 
     private int httpStatusCode;
-    private Map<String, List<String>> responseHeaders;
+    private transient Map<String, List<String>> responseHeaders;
 
     /** 
      * Get the HTTP status code from the response.

--- a/pipeline.cloudrequestengine/src/main/java/fiftyone/pipeline/cloudrequestengine/flowelements/CloudAspectEngineBase.java
+++ b/pipeline.cloudrequestengine/src/main/java/fiftyone/pipeline/cloudrequestengine/flowelements/CloudAspectEngineBase.java
@@ -116,6 +116,7 @@ public abstract class CloudAspectEngineBase<TData extends AspectData>
      * @param aspectDataFactory the factory to use when creating a TData
      *                          instance
      */
+    @SuppressWarnings("this-escape")
     public CloudAspectEngineBase(
         Logger logger,
         ElementDataFactory<TData> aspectDataFactory) {

--- a/pipeline.cloudrequestengine/src/main/java/fiftyone/pipeline/cloudrequestengine/flowelements/CloudRequestEngineDefault.java
+++ b/pipeline.cloudrequestengine/src/main/java/fiftyone/pipeline/cloudrequestengine/flowelements/CloudRequestEngineDefault.java
@@ -43,6 +43,9 @@ import org.slf4j.Logger;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -121,6 +124,7 @@ public class CloudRequestEngineDefault
             cloudRequestOrigin);
     }
 
+    @SuppressWarnings("this-escape")
     public CloudRequestEngineDefault(
         Logger logger,
         ElementDataFactory<CloudRequestData> aspectDataFactory,
@@ -208,7 +212,7 @@ public class CloudRequestEngineDefault
     @Override
     protected void processEngine(FlowData data, CloudRequestData aspectData) throws IOException {
         byte[] content = getContent(data);
-        HttpURLConnection connection = httpClient.connect(new URL(endPoint.trim()));
+        HttpURLConnection connection = httpClient.connect(toUrl(endPoint.trim()));
         if (timeoutMillis != null) {
             connection.setConnectTimeout(timeoutMillis);
             connection.setReadTimeout(timeoutMillis);
@@ -386,6 +390,27 @@ public class CloudRequestEngineDefault
         }
     }
 
+    /**
+     * Convert a string into a {@link URL} instance.
+     * <p>
+     * Replaces the deprecated {@code new URL(String)} constructor with
+     * {@link URI#toURL()}, translating the checked {@link URISyntaxException}
+     * into a {@link MalformedURLException} so that callers continue to see the
+     * same {@link java.io.IOException} as they did previously.
+     * @param spec the string to parse as a URL
+     * @return the parsed {@link URL}
+     * @throws MalformedURLException if the string is not a valid URL
+     */
+    private static URL toUrl(String spec) throws MalformedURLException {
+        try {
+            return new URI(spec).toURL();
+        } catch (URISyntaxException e) {
+            MalformedURLException ex = new MalformedURLException(e.getMessage());
+            ex.initCause(e);
+            throw ex;
+        }
+    }
+
     private void getCloudProperties() throws CloudRequestException, AggregateException, PropertyNotLoadedException {
         try {
             String jsonResult;
@@ -393,7 +418,7 @@ public class CloudRequestEngineDefault
             Map<String, String> headers = new HashMap<>();
             setCommonHeaders(headers);
 
-            HttpURLConnection connection = httpClient.connect(new URL(propertiesEndpoint.trim() + (resourceKey != null ? "?Resource=" + resourceKey : "")));
+            HttpURLConnection connection = httpClient.connect(toUrl(propertiesEndpoint.trim() + (resourceKey != null ? "?Resource=" + resourceKey : "")));
             jsonResult = httpClient.getResponseString(connection, headers);
             validateResponse(jsonResult, connection);
 
@@ -423,7 +448,7 @@ public class CloudRequestEngineDefault
             Map<String, String> headers = new HashMap<>();
             setCommonHeaders(headers);
 
-            HttpURLConnection connection = httpClient.connect(new URL(evidenceKeysEndpoint.trim()));
+            HttpURLConnection connection = httpClient.connect(toUrl(evidenceKeysEndpoint.trim()));
             jsonResult = httpClient.getResponseString(connection, headers);
             validateResponse(jsonResult, connection, false);
 

--- a/pipeline.cloudrequestengine/src/test/java/fiftyone/pipeline/cloudrequestengine/flowelements/CloudRequestEngineTestsBase.java
+++ b/pipeline.cloudrequestengine/src/test/java/fiftyone/pipeline/cloudrequestengine/flowelements/CloudRequestEngineTestsBase.java
@@ -33,6 +33,7 @@ import org.slf4j.Logger;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
@@ -45,7 +46,7 @@ public class CloudRequestEngineTestsBase {
 	HttpClient httpClient;
     protected TestLoggerFactory loggerFactory;
 
-    protected URL expectedUrl = new URL("https://cloud.51degrees.com/api/v4/resource_key.json");
+    protected URL expectedUrl = URI.create("https://cloud.51degrees.com/api/v4/resource_key.json").toURL();
     protected String jsonResponse = "{'device':{'value':'1'}}";
     protected String evidenceKeysResponse = "['query.User-Agent']";
     protected String accessiblePropertiesResponse =

--- a/pipeline.core/src/main/java/fiftyone/pipeline/core/flowelements/FlowElementBase.java
+++ b/pipeline.core/src/main/java/fiftyone/pipeline/core/flowelements/FlowElementBase.java
@@ -64,6 +64,7 @@ public abstract class FlowElementBase<
      * @param elementDataFactory the factory to use when creating a
      *                           {@link ElementDataBase} instance
      */
+    @SuppressWarnings("this-escape")
     public FlowElementBase(
             Logger logger,
             ElementDataFactory<TData> elementDataFactory) {

--- a/pipeline.core/src/main/java/fiftyone/pipeline/exceptions/AggregateException.java
+++ b/pipeline.core/src/main/java/fiftyone/pipeline/exceptions/AggregateException.java
@@ -41,6 +41,7 @@ public class AggregateException extends RuntimeException {
      * @param message the message to give to the exception
      * @param causes multiple causes to be contained in the exception
      */
+    @SuppressWarnings("this-escape")
     public AggregateException(String message, Collection<Throwable> causes) {
         super(message);
         for (Throwable cause : causes) {
@@ -52,6 +53,7 @@ public class AggregateException extends RuntimeException {
      * Construct a new instance with no message.
      * @param causes multiple causes to be contained in the exception
      */
+    @SuppressWarnings("this-escape")
     public AggregateException(Collection<Throwable> causes) {
         super();
         for (Throwable cause : causes) {

--- a/pipeline.core/src/main/java/fiftyone/pipeline/util/FiftyOneLookup.java
+++ b/pipeline.core/src/main/java/fiftyone/pipeline/util/FiftyOneLookup.java
@@ -91,6 +91,7 @@ public class FiftyOneLookup {
      * which is not what we want.
      */
     public static class FiftyOneStringSubstitutor extends StringSubstitutor {
+        @SuppressWarnings("this-escape")
         public FiftyOneStringSubstitutor(StringLookup variableResolver) {
             super(variableResolver);
             setEnableSubstitutionInVariables(true);

--- a/pipeline.core/src/test/java/fiftyone/pipeline/core/data/WeightedValueTests.java
+++ b/pipeline.core/src/test/java/fiftyone/pipeline/core/data/WeightedValueTests.java
@@ -41,7 +41,7 @@ public class WeightedValueTests {
     @Test
     public void WeightedValue_GetWeighting_05() {
         IWeightedValue<?>[] values =
-        new IWeightedValue[]{
+        new IWeightedValue<?>[]{
                 new WeightedValue<>(MAX_RAW_WEIGHTING / 2 + 1, 5),
                 new WeightedValue<>(MAX_RAW_WEIGHTING / 2, 13),
         };

--- a/pipeline.engines.fiftyone/src/main/java/fiftyone/pipeline/engines/fiftyone/data/FiftyOneAspectPropertyMetaDataDefault.java
+++ b/pipeline.engines.fiftyone/src/main/java/fiftyone/pipeline/engines/fiftyone/data/FiftyOneAspectPropertyMetaDataDefault.java
@@ -45,6 +45,7 @@ public class FiftyOneAspectPropertyMetaDataDefault
     private final Iterable<ValueMetaDataDefault> values;
     private final ValueMetaDataDefault defaultValue;
 
+    @SuppressWarnings("this-escape")
     public FiftyOneAspectPropertyMetaDataDefault(
         String name,
         FlowElement<?,?> element,

--- a/pipeline.engines.fiftyone/src/main/java/fiftyone/pipeline/engines/fiftyone/flowelements/FiftyOneOnPremiseAspectEngineBuilderBase.java
+++ b/pipeline.engines.fiftyone/src/main/java/fiftyone/pipeline/engines/fiftyone/flowelements/FiftyOneOnPremiseAspectEngineBuilderBase.java
@@ -71,6 +71,7 @@ public abstract class FiftyOneOnPremiseAspectEngineBuilderBase<
      * @param dataUpdateService the {@link DataUpdateService} to use when
      *                          automatic updates happen on the data file
      */
+    @SuppressWarnings("this-escape")
     public FiftyOneOnPremiseAspectEngineBuilderBase(
         ILoggerFactory loggerFactory,
         DataUpdateService dataUpdateService) {

--- a/pipeline.engines.fiftyone/src/main/java/fiftyone/pipeline/engines/fiftyone/flowelements/SetHeadersElement.java
+++ b/pipeline.engines.fiftyone/src/main/java/fiftyone/pipeline/engines/fiftyone/flowelements/SetHeadersElement.java
@@ -74,6 +74,7 @@ public class SetHeadersElement
 	private final List<ElementPropertyMetaData> properties;
 	private final Hashtable<Pipeline, PipelineConfig> pipelineConfigs;
 
+	@SuppressWarnings("this-escape")
 	public SetHeadersElement(
 		Logger logger,
 		ElementDataFactory<SetHeadersData> elementDataFactory) {

--- a/pipeline.engines.fiftyone/src/main/java/fiftyone/pipeline/engines/fiftyone/flowelements/ShareUsageBase.java
+++ b/pipeline.engines.fiftyone/src/main/java/fiftyone/pipeline/engines/fiftyone/flowelements/ShareUsageBase.java
@@ -410,7 +410,7 @@ public abstract class ShareUsageBase
         languageVersion = System.getProperty("java.version");
         osVersion = System.getProperty("os.name");
 
-        setEnginesVersion(getClass().getPackage().getImplementationVersion());
+        this.enginesVersion = getClass().getPackage().getImplementationVersion();
         coreVersion = Pipeline.class.getPackage().getImplementationVersion();
 
         includedQueryStringParameters.add(Constants.EVIDENCE_SESSIONID_SUFFIX);

--- a/pipeline.engines.fiftyone/src/main/java/fiftyone/pipeline/engines/fiftyone/flowelements/ShareUsageBuilderBase.java
+++ b/pipeline.engines.fiftyone/src/main/java/fiftyone/pipeline/engines/fiftyone/flowelements/ShareUsageBuilderBase.java
@@ -30,6 +30,8 @@ import org.slf4j.Logger;
 import java.io.IOException;
 import java.net.HttpCookie;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.*;
 
@@ -357,9 +359,9 @@ public abstract class ShareUsageBuilderBase<T extends ShareUsageBase> {
     @DefaultValue(value="Send to 51D - " + Constants.SHARE_USAGE_DEFAULT_URL)
     public ShareUsageBuilderBase<T> setShareUsageUrl(String shareUsageUrl) {
         try {
-            URL url = new URL(shareUsageUrl);
+            URL url = new URI(shareUsageUrl).toURL();
             assert !url.toString().isEmpty();
-        } catch (MalformedURLException e) {
+        } catch (MalformedURLException | URISyntaxException e) {
             throw new IllegalArgumentException(e);
         }
         this.shareUsageUrl = shareUsageUrl;

--- a/pipeline.engines.fiftyone/src/main/java/fiftyone/pipeline/engines/fiftyone/flowelements/ShareUsageElement.java
+++ b/pipeline.engines.fiftyone/src/main/java/fiftyone/pipeline/engines/fiftyone/flowelements/ShareUsageElement.java
@@ -37,7 +37,7 @@ import javax.xml.stream.XMLStreamWriter;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
-import java.net.URL;
+import java.net.URI;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -545,7 +545,7 @@ public class ShareUsageElement extends ShareUsageBase {
             streamXml(allData, os);
         }
 
-        HttpURLConnection connection = httpClient.connect(new URL(shareUsageUrl.trim()));
+        HttpURLConnection connection = httpClient.connect(new URI(shareUsageUrl.trim()).toURL());
         String response = httpClient.postData(connection, headers, baos.toByteArray());
         int responseCode = connection.getResponseCode();
         String responseMessage = connection.getResponseMessage() + "data: '" + response + "'";

--- a/pipeline.engines.fiftyone/src/main/java/fiftyone/pipeline/engines/fiftyone/flowelements/interop/LibLoader.java
+++ b/pipeline.engines.fiftyone/src/main/java/fiftyone/pipeline/engines/fiftyone/flowelements/interop/LibLoader.java
@@ -129,6 +129,7 @@ public class LibLoader {
      *                                       a native library for the environment
      * @throws IOException thrown if there is a problem copying the resource
      */
+    @SuppressWarnings("restricted")
     public static void load(Class<?> engineClass)
         throws IOException, UnsupportedOperationException {
         File nativeLibraryFile = copyResource(

--- a/pipeline.engines/src/main/java/fiftyone/pipeline/engines/data/AspectPropertyValueDefault.java
+++ b/pipeline.engines/src/main/java/fiftyone/pipeline/engines/data/AspectPropertyValueDefault.java
@@ -49,7 +49,8 @@ public class AspectPropertyValueDefault<T> implements AspectPropertyValue<T> {
      * @param value the value to set
      */
     public AspectPropertyValueDefault(T value) {
-        setValue(value);
+        this.hasValue = true;
+        this.value = value;
     }
 
     @Override

--- a/pipeline.engines/src/main/java/fiftyone/pipeline/engines/exceptions/PropertyMissingException.java
+++ b/pipeline.engines/src/main/java/fiftyone/pipeline/engines/exceptions/PropertyMissingException.java
@@ -57,7 +57,7 @@ public class PropertyMissingException extends RuntimeException {
         String propertyName,
         String message) {
         super(message);
-        this.setReason(reason);
+        this.reason = reason;
         this.propertyName = propertyName;
     }
 
@@ -76,7 +76,7 @@ public class PropertyMissingException extends RuntimeException {
         String message,
         Throwable cause) {
         super(message, cause);
-        this.setReason(reason);
+        this.reason = reason;
         this.propertyName = propertyName;
     }
 

--- a/pipeline.engines/src/main/java/fiftyone/pipeline/engines/flowelements/OnPremiseAspectEngineBase.java
+++ b/pipeline.engines/src/main/java/fiftyone/pipeline/engines/flowelements/OnPremiseAspectEngineBase.java
@@ -69,7 +69,7 @@ public abstract class OnPremiseAspectEngineBase<
         String tempDataDirPath) {
         super(logger, aspectDataFactory);
         this.dataFiles = new ArrayList<>();
-        setTempDataDirPath(tempDataDirPath);
+        this.tempDataDirPath = tempDataDirPath;
     }
 
     @Override

--- a/pipeline.engines/src/main/java/fiftyone/pipeline/engines/flowelements/OnPremiseAspectEngineBuilderBase.java
+++ b/pipeline.engines/src/main/java/fiftyone/pipeline/engines/flowelements/OnPremiseAspectEngineBuilderBase.java
@@ -99,7 +99,7 @@ public abstract class OnPremiseAspectEngineBuilderBase<
         createAndVerifyTempDir(Paths.get(tempDir));
     }
 
-    public void createAndVerifyTempDir(Path pathToCreate) {
+    public final void createAndVerifyTempDir(Path pathToCreate) {
         try {
             File directory = pathToCreate.toFile();
             if (isFalse(directory.exists())) {

--- a/pipeline.engines/src/main/java/fiftyone/pipeline/engines/services/DataUpdateServiceDefault.java
+++ b/pipeline.engines/src/main/java/fiftyone/pipeline/engines/services/DataUpdateServiceDefault.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.net.HttpURLConnection;
-import java.net.URL;
+import java.net.URI;
 import java.nio.file.*;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
@@ -596,7 +596,7 @@ public class DataUpdateServiceDefault implements DataUpdateService {
         logger.debug("downloadFile from {}", url);
 
         try {
-            HttpURLConnection connection = httpClient.connect(new URL(url.trim()));
+            HttpURLConnection connection = httpClient.connect(new URI(url.trim()).toURL());
             if (connection == null) {
                 logger.error("No response from data update service at '{}' for engine '{}'",
                         dataFile.getFormattedUrl(), Objects.nonNull(dataFile.getEngine()) ?

--- a/pipeline.engines/src/main/java/fiftyone/pipeline/engines/services/DataUploaderHttp.java
+++ b/pipeline.engines/src/main/java/fiftyone/pipeline/engines/services/DataUploaderHttp.java
@@ -25,7 +25,7 @@ package fiftyone.pipeline.engines.services;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
-import java.net.URL;
+import java.net.URI;
 import java.util.Map;
 import java.util.zip.GZIPOutputStream;
 
@@ -53,7 +53,7 @@ public class DataUploaderHttp implements DataUploader{
      */
     @Override
     public OutputStream getOutputStream() throws Exception{
-        connection = (HttpURLConnection) new URL(url.trim()).openConnection();
+        connection = (HttpURLConnection) new URI(url.trim()).toURL().openConnection();
         connection.setConnectTimeout(timeout);
         connection.setRequestMethod("POST");
         for (Map.Entry<String, String> header : headers.entrySet()) {

--- a/pipeline.engines/src/test/java/fiftyone/pipeline/engines/services/HttpClientTests.java
+++ b/pipeline.engines/src/test/java/fiftyone/pipeline/engines/services/HttpClientTests.java
@@ -28,7 +28,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
-import java.net.URL;
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -55,7 +55,7 @@ public class HttpClientTests {
     String result = null;
 
     try{
-      HttpURLConnection connection = client.connect(new URL(testUrl));
+      HttpURLConnection connection = client.connect(URI.create(testUrl).toURL());
       result = client.getResponseString(connection);
     } catch (IOException ex) {
       assertTrue("Unexpected exception: " + ex.getMessage(), false);
@@ -81,7 +81,7 @@ public class HttpClientTests {
     headers.put("Origin", "51degrees.com");
     
     try{
-      HttpURLConnection connection = client.connect(new URL(testUrl));
+      HttpURLConnection connection = client.connect(URI.create(testUrl).toURL());
       result = client.getResponseString(connection, headers);
       code = connection.getResponseCode();
     } catch (IOException ex) {

--- a/pipeline.engines/src/test/java/fiftyone/pipeline/engines/testhelpers/flowelements/EmptyEngine.java
+++ b/pipeline.engines/src/test/java/fiftyone/pipeline/engines/testhelpers/flowelements/EmptyEngine.java
@@ -47,8 +47,10 @@ public class EmptyEngine
     private EvidenceKeyFilterWhitelist evidenceWhitelist =
         new EvidenceKeyFilterWhitelist(Arrays.asList("test.value"));
 
+    @SuppressWarnings("this-escape")
     private final TypedKey<EmptyEngineData> typedKey = new TypedKeyDefault<>(getElementDataKey(), EmptyEngineData.class);
 
+    @SuppressWarnings("this-escape")
     public EmptyEngine(
         Logger logger,
         ElementDataFactory<EmptyEngineData> aspectDataFactory) {

--- a/pipeline.jsonbuilder/src/main/java/fiftyone/pipeline/jsonbuilder/flowelements/JsonBuilderElement.java
+++ b/pipeline.jsonbuilder/src/main/java/fiftyone/pipeline/jsonbuilder/flowelements/JsonBuilderElement.java
@@ -72,6 +72,7 @@ public class JsonBuilderElement
      * @param logger The logger.
      * @param elementDataFactory The element data factory.
      */
+    @SuppressWarnings("this-escape")
     public JsonBuilderElement(
             Logger logger,
             ElementDataFactory<JsonBuilderData> elementDataFactory) {

--- a/pipeline.web.packages/pipeline.web/src/main/java/fiftyone/pipeline/web/services/ClientsidePropertyServiceCore.java
+++ b/pipeline.web.packages/pipeline.web/src/main/java/fiftyone/pipeline/web/services/ClientsidePropertyServiceCore.java
@@ -141,7 +141,7 @@ public interface ClientsidePropertyServiceCore {
          * Initialise the service.
          */
         @SuppressWarnings("rawtypes")
-        protected void init() {
+        protected final void init() {
             headersAffectingJavaScript = new ArrayList<>();
             // Get evidence filters for all elements.
             List<EvidenceKeyFilter> filters = new ArrayList<>();

--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
                         <showWarnings>true</showWarnings>
                         <compilerArgs>
                             <arg>-Xlint:all,-try,-options</arg>
-<!--                            <arg>-Werror</arg>-->
+                            <arg>-Werror</arg>
                         </compilerArgs>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
- Eliminate this-escape where cheap: inline trivial setters to direct field writes; make createAndVerifyTempDir/init final
- Suppress remaining benign this-escape (this passed to collaborators, super.addSuppressed, superclass/builder setters)
- Replace deprecated new URL(String) with URI-based construction
- Mark non-serializable CloudRequestException.responseHeaders transient
- Uncomment -Werror to prevent warning regressions
- Correct declaration of IWeightedValue<?>[]
- @SuppressWarnings("restricted") on load()