### PR TITLE
Add a generic translation flow element (pipeline.translation)

### DIFF
--- a/pipeline.translation/pom.xml
+++ b/pipeline.translation/pom.xml
@@ -40,6 +40,14 @@
             <artifactId>pipeline.engines</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- snakeyaml-engine is YAML 1.2, which (unlike YAML 1.1 parsers)
+             keeps the country code "NO" as the string "NO" rather than the
+             boolean false. -->
+        <dependency>
+            <groupId>org.snakeyaml</groupId>
+            <artifactId>snakeyaml-engine</artifactId>
+            <version>2.7</version>
+        </dependency>
 
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/pipeline.translation/pom.xml
+++ b/pipeline.translation/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+  ~ Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+  ~ Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+  ~
+  ~ This Original Work is licensed under the European Union Public Licence
+  ~  (EUPL) v.1.2 and is subject to its terms as set out below.
+  ~
+  ~  If a copy of the EUPL was not distributed with this file, You can obtain
+  ~  one at https://opensource.org/licenses/EUPL-1.2.
+  ~
+  ~  The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+  ~  amended by the European Commission) shall be deemed incompatible for
+  ~  the purposes of the Work and the provisions of the compatibility
+  ~  clause in Article 5 of the EUPL shall not apply.
+  ~
+  ~   If using the Work as, or as part of, a network application, by
+  ~   including the attribution notice(s) required under Article 5 of the EUPL
+  ~   in the end user terms of the application under an appropriate heading,
+  ~   such notice(s) shall fulfill the requirements of that article.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.51degrees</groupId>
+        <artifactId>pipeline</artifactId>
+        <version>4.5.7-SNAPSHOT</version>
+    </parent>
+    <artifactId>pipeline.translation</artifactId>
+    <packaging>jar</packaging>
+
+    <name>51Degrees :: Pipeline :: Translation</name>
+    <url>https://51degrees.com?utm_source=maven&amp;utm_medium=package&amp;utm_campaign=pipeline-java&amp;utm_content=pipeline.translation-pom.xml&amp;utm_term=url</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>pipeline.engines</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>pipeline.core</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/pipeline.translation/src/main/java/fiftyone/pipeline/translation/data/ITranslationData.java
+++ b/pipeline.translation/src/main/java/fiftyone/pipeline/translation/data/ITranslationData.java
@@ -1,0 +1,32 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+package fiftyone.pipeline.translation.data;
+
+import fiftyone.pipeline.core.data.ElementData;
+
+/**
+ * Element data marker interface for
+ * {@link fiftyone.pipeline.translation.flowelements.TranslationEngine}.
+ */
+public interface ITranslationData extends ElementData {
+}

--- a/pipeline.translation/src/main/java/fiftyone/pipeline/translation/data/Languages.java
+++ b/pipeline.translation/src/main/java/fiftyone/pipeline/translation/data/Languages.java
@@ -1,0 +1,237 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+package fiftyone.pipeline.translation.data;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Set of translators for one or more languages, with static utility methods
+ * for parsing Accept-Language header values and resolving language tags
+ * against the available locales.
+ */
+public class Languages {
+
+    /**
+     * The result of matching a language tag against the available locales: the
+     * translator to use and the locale key that was matched.
+     */
+    public static class Match {
+
+        private final Translator translator;
+        private final String locale;
+
+        Match(Translator translator, String locale) {
+            this.translator = translator;
+            this.locale = locale;
+        }
+
+        /**
+         * @return the translator for the matched locale
+         */
+        public Translator getTranslator() {
+            return translator;
+        }
+
+        /**
+         * @return the locale key that was matched (e.g. "fr_FR")
+         */
+        public String getLocale() {
+            return locale;
+        }
+    }
+
+    /**
+     * Internal dictionary of translators keyed case-insensitively by locale.
+     */
+    private final Map<String, Translator> translators =
+        new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+
+    /**
+     * Add a language and its translator to the set of languages.
+     * @param language locale code for the language e.g. "en_GB", "fr_FR"
+     * @param translator translator for the language
+     */
+    public void addLanguage(String language, Translator translator) {
+        if (language == null || translator == null) {
+            throw new IllegalArgumentException(
+                "Language and translator must not be null.");
+        }
+        translators.put(language, translator);
+    }
+
+    /**
+     * Match the supplied language tag (a locale code or a full Accept-Language
+     * header value) against the available locales.
+     * @param language a locale code (e.g. "fr_FR") or an Accept-Language header
+     *                value (e.g. "es,de-DE;q=0.8,en;q=0.5")
+     * @return the matched translator and locale, or null if no match was found
+     */
+    public Match match(String language) {
+        String locale = resolveLocale(language, translators.keySet(), "en");
+        if (locale == null) {
+            return null;
+        }
+        Translator translator = translators.get(locale);
+        if (translator == null) {
+            return null;
+        }
+        return new Match(translator, locale);
+    }
+
+    /**
+     * Get the translator for the supplied language tag, or null if none of the
+     * available locales match.
+     * @param language a locale code or an Accept-Language header value
+     * @return the matched translator, or null
+     */
+    public Translator getTranslator(String language) {
+        Match m = match(language);
+        return m == null ? null : m.getTranslator();
+    }
+
+    /**
+     * Parse an Accept-Language header value (e.g.
+     * "es,de-DE;q=0.8,en;q=0.5") into an ordered list of normalised language
+     * tags. Tags are ordered by quality (descending, stable so equal-quality
+     * tags keep their original order), with dashes replaced by underscores
+     * (e.g. "en-GB" becomes "en_GB").
+     * @param acceptLanguage the raw Accept-Language header value
+     * @return ordered list of normalised language tags, highest preference
+     *         first
+     */
+    public static List<String> parseAcceptLanguage(String acceptLanguage) {
+        List<String> result = new ArrayList<>();
+        if (acceptLanguage == null || acceptLanguage.trim().isEmpty()) {
+            return result;
+        }
+
+        List<Ranking> rankings = new ArrayList<>();
+        for (String part : acceptLanguage.split(",")) {
+            String[] tokens = part.split(";");
+            String value = tokens[0].trim().replace('-', '_');
+            if (value.isEmpty()) {
+                continue;
+            }
+            double quality = 1.0;
+            for (int i = 1; i < tokens.length; i++) {
+                String token = tokens[i].trim();
+                if (token.startsWith("q=")) {
+                    try {
+                        quality = Double.parseDouble(token.substring(2).trim());
+                    } catch (NumberFormatException e) {
+                        quality = 1.0;
+                    }
+                }
+            }
+            rankings.add(new Ranking(value, quality));
+        }
+
+        // Stable sort by quality descending preserves the original order for
+        // equal-quality tags.
+        rankings.sort(new Comparator<Ranking>() {
+            @Override
+            public int compare(Ranking a, Ranking b) {
+                return Double.compare(b.quality, a.quality);
+            }
+        });
+
+        for (Ranking ranking : rankings) {
+            result.add(ranking.value);
+        }
+        return result;
+    }
+
+    /**
+     * Resolve an Accept-Language header value against a set of available locale
+     * keys, returning the best matching locale. Handles both exact locale
+     * matches (e.g. "fr_FR") and 2-character language code fallbacks (e.g.
+     * "fr" matching "fr_FR").
+     * <p>
+     * If the highest-priority candidate's language matches
+     * {@code baseLanguage} (e.g. "en"), resolution stops immediately and
+     * returns null, since the source values are already in the base language
+     * and no translation is needed. This prevents falling through to a
+     * lower-priority language.
+     * @param acceptLanguage the raw Accept-Language header value
+     * @param availableLocales the set of available locale keys
+     * @param baseLanguage the 2-char code of the base language the source
+     *                     values are already in (e.g. "en"); may be null
+     * @return the matched locale key, or null if no match was found
+     */
+    public static String resolveLocale(
+        String acceptLanguage,
+        Collection<String> availableLocales,
+        String baseLanguage) {
+        for (String candidate : parseAcceptLanguage(acceptLanguage)) {
+            // Exact match first.
+            for (String locale : availableLocales) {
+                if (locale.equalsIgnoreCase(candidate)) {
+                    return locale;
+                }
+            }
+
+            // No exact match. If this candidate's language is the base
+            // language, the source values are already in that language: stop
+            // and return null rather than falling through to a lower-priority
+            // language.
+            if (baseLanguage != null &&
+                startsWithIgnoreCase(candidate, baseLanguage)) {
+                return null;
+            }
+
+            // 2-char language code fallback (e.g. "fr" matches "fr_FR").
+            if (candidate.length() == 2) {
+                for (String locale : availableLocales) {
+                    if (startsWithIgnoreCase(locale, candidate)) {
+                        return locale;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private static boolean startsWithIgnoreCase(String value, String prefix) {
+        return value.length() >= prefix.length() &&
+            value.regionMatches(true, 0, prefix, 0, prefix.length());
+    }
+
+    /**
+     * A parsed Accept-Language entry: the normalised tag and its quality.
+     */
+    private static class Ranking {
+
+        private final String value;
+        private final double quality;
+
+        Ranking(String value, double quality) {
+            this.value = value;
+            this.quality = quality;
+        }
+    }
+}

--- a/pipeline.translation/src/main/java/fiftyone/pipeline/translation/data/MissingTranslationBehavior.java
+++ b/pipeline.translation/src/main/java/fiftyone/pipeline/translation/data/MissingTranslationBehavior.java
@@ -1,0 +1,47 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+package fiftyone.pipeline.translation.data;
+
+/**
+ * Defines the behaviour of the translation engine when a translation is
+ * missing for a value.
+ */
+public enum MissingTranslationBehavior {
+
+    /**
+     * Use the original value if there is no translation for it. This is the
+     * default behaviour.
+     */
+    ORIGINAL,
+
+    /**
+     * Use an empty string if there is no translation for the value.
+     */
+    EMPTY_STRING,
+
+    /**
+     * Add a flow error if there is no translation for the value. The error
+     * contains the reason there was no translation.
+     */
+    FLOW_ERROR
+}

--- a/pipeline.translation/src/main/java/fiftyone/pipeline/translation/data/TranslationData.java
+++ b/pipeline.translation/src/main/java/fiftyone/pipeline/translation/data/TranslationData.java
@@ -1,0 +1,58 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+package fiftyone.pipeline.translation.data;
+
+import fiftyone.pipeline.core.data.ElementDataBase;
+import fiftyone.pipeline.core.data.FlowData;
+import org.slf4j.Logger;
+
+import java.util.Map;
+
+/**
+ * Data object populated by
+ * {@link fiftyone.pipeline.translation.flowelements.TranslationEngine}.
+ */
+public class TranslationData extends ElementDataBase implements ITranslationData {
+
+    /**
+     * Construct a new instance.
+     * @param logger used for logging
+     * @param flowData the {@link FlowData} the element data will be added to
+     */
+    public TranslationData(Logger logger, FlowData flowData) {
+        super(logger, flowData);
+    }
+
+    /**
+     * Construct a new instance using an existing map of values.
+     * @param logger used for logging
+     * @param flowData the {@link FlowData} the element data will be added to
+     * @param data the values to populate the element data with
+     */
+    public TranslationData(
+        Logger logger,
+        FlowData flowData,
+        Map<String, Object> data) {
+        super(logger, flowData, data);
+    }
+}

--- a/pipeline.translation/src/main/java/fiftyone/pipeline/translation/data/TranslationProperty.java
+++ b/pipeline.translation/src/main/java/fiftyone/pipeline/translation/data/TranslationProperty.java
@@ -1,0 +1,59 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+package fiftyone.pipeline.translation.data;
+
+/**
+ * Defines a translation from one property to another.
+ */
+public class TranslationProperty {
+
+    private final String sourceProperty;
+    private final String destinationProperty;
+
+    /**
+     * Construct a new instance.
+     * @param source the name of the source property on the source element data
+     * @param destination the name of the destination property to store the
+     *                    translated value under on the translation engine data
+     */
+    public TranslationProperty(String source, String destination) {
+        this.sourceProperty = source;
+        this.destinationProperty = destination;
+    }
+
+    /**
+     * Source property name on the source element data.
+     * @return source property name
+     */
+    public String getSourceProperty() {
+        return sourceProperty;
+    }
+
+    /**
+     * Destination property name on the translation engine data.
+     * @return destination property name
+     */
+    public String getDestinationProperty() {
+        return destinationProperty;
+    }
+}

--- a/pipeline.translation/src/main/java/fiftyone/pipeline/translation/data/Translator.java
+++ b/pipeline.translation/src/main/java/fiftyone/pipeline/translation/data/Translator.java
@@ -1,0 +1,193 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+package fiftyone.pipeline.translation.data;
+
+import fiftyone.pipeline.core.data.IWeightedValue;
+import fiftyone.pipeline.core.data.WeightedValue;
+import fiftyone.pipeline.engines.data.AspectPropertyValue;
+import fiftyone.pipeline.engines.data.AspectPropertyValueDefault;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.TreeMap;
+
+/**
+ * Translator used to translate values based on a set of translations. The
+ * translator supports translating various string based types. The result is
+ * the same type as the source e.g. a string will be translated to a string, a
+ * list of strings will be translated to a list of strings, a weighted list of
+ * strings to a weighted list of strings (preserving each item's weight), etc.
+ * <p>
+ * For {@link AspectPropertyValue} types, if the value has no value then the no
+ * value message is copied to the result.
+ */
+public class Translator {
+
+    /**
+     * Internal translation lookup, keyed case-insensitively.
+     */
+    private final Map<String, String> translations;
+
+    /**
+     * The behaviour to use when a translation is missing.
+     */
+    private final MissingTranslationBehavior behavior;
+
+    /**
+     * Construct a translator with no translations configured. Every value will
+     * use the missing-translation behaviour.
+     * @param behavior the behaviour to use when a translation is missing
+     */
+    public Translator(MissingTranslationBehavior behavior) {
+        this(null, behavior);
+    }
+
+    /**
+     * Construct a translator.
+     * @param translations the translations to use. The key is the source value
+     *                     and the value is the translated value. May be null
+     *                     for an empty translator.
+     * @param behavior the behaviour to use when a translation is missing
+     */
+    public Translator(
+        Map<String, String> translations,
+        MissingTranslationBehavior behavior) {
+        this.translations = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        if (translations != null) {
+            this.translations.putAll(translations);
+        }
+        this.behavior = behavior;
+    }
+
+    /**
+     * Translate the value to the language this translator is configured for.
+     * Supports a {@link String}, a {@link List} of strings, a {@link List} of
+     * {@link IWeightedValue} of strings, and {@link AspectPropertyValue}
+     * wrappers around any of those. The result has the same shape as the
+     * input.
+     * @param value the value to translate
+     * @param errors list to which errors encountered during translation are
+     *               added
+     * @return the translated value, with the same type as the source
+     */
+    public Object translate(Object value, List<Exception> errors) {
+        if (value instanceof String) {
+            return translateString((String) value, errors);
+        }
+        if (value instanceof AspectPropertyValue) {
+            return translateAspect((AspectPropertyValue<?>) value, errors);
+        }
+        if (value instanceof List) {
+            return translateList((List<?>) value, errors);
+        }
+        throw new UnsupportedOperationException("The value type '" +
+            (value == null ? "null" : value.getClass().getName()) +
+            "' is not supported for translation.");
+    }
+
+    /**
+     * Translate a single string value, applying the missing-translation
+     * behaviour when no (non-blank) translation exists.
+     */
+    private String translateString(String value, List<Exception> errors) {
+        if (value != null) {
+            String result = translations.get(value);
+            if (result != null && result.trim().isEmpty() == false) {
+                return result;
+            }
+        }
+        switch (behavior) {
+            case EMPTY_STRING:
+                return "";
+            case FLOW_ERROR:
+                errors.add(new NoSuchElementException(
+                    "There was no translation found for the value '" +
+                    value + "'."));
+                return null;
+            case ORIGINAL:
+            default:
+                return value;
+        }
+    }
+
+    /**
+     * Translate a list of either plain strings or weighted strings. The
+     * element type is determined from the first non-null element. Weighted
+     * items keep their raw weighting; only the value is translated.
+     */
+    private Object translateList(List<?> values, List<Exception> errors) {
+        Object sample = null;
+        for (Object item : values) {
+            if (item != null) {
+                sample = item;
+                break;
+            }
+        }
+        if (sample instanceof IWeightedValue) {
+            List<IWeightedValue<String>> result =
+                new ArrayList<>(values.size());
+            for (Object item : values) {
+                @SuppressWarnings("unchecked")
+                IWeightedValue<String> weighted = (IWeightedValue<String>) item;
+                result.add(new WeightedValue<>(
+                    weighted.getRawWeighting(),
+                    translateString(weighted.getValue(), errors)));
+            }
+            return result;
+        }
+        List<String> result = new ArrayList<>(values.size());
+        for (Object item : values) {
+            result.add(translateString((String) item, errors));
+        }
+        return result;
+    }
+
+    /**
+     * Translate the value wrapped by an {@link AspectPropertyValue}, copying
+     * the no-value message when the source has no value.
+     */
+    private AspectPropertyValue<Object> translateAspect(
+        AspectPropertyValue<?> value,
+        List<Exception> errors) {
+        if (value.hasValue() == false) {
+            AspectPropertyValueDefault<Object> result =
+                new AspectPropertyValueDefault<>();
+            result.setNoValueMessage(value.getNoValueMessage());
+            return result;
+        }
+        Object inner = value.getValue();
+        Object translated;
+        if (inner instanceof List) {
+            translated = translateList((List<?>) inner, errors);
+        } else if (inner instanceof String) {
+            translated = translateString((String) inner, errors);
+        } else {
+            throw new UnsupportedOperationException("The value type '" +
+                (inner == null ? "null" : inner.getClass().getName()) +
+                "' is not supported for translation.");
+        }
+        return new AspectPropertyValueDefault<>(translated);
+    }
+}

--- a/pipeline.translation/src/main/java/fiftyone/pipeline/translation/flowelements/ITranslationEngine.java
+++ b/pipeline.translation/src/main/java/fiftyone/pipeline/translation/flowelements/ITranslationEngine.java
@@ -1,0 +1,42 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+package fiftyone.pipeline.translation.flowelements;
+
+import fiftyone.pipeline.core.data.ElementPropertyMetaData;
+import fiftyone.pipeline.core.flowelements.FlowElement;
+import fiftyone.pipeline.translation.data.ITranslationData;
+
+/**
+ * Flow element that translates values from a single source element and stores
+ * translated values under its own element data key. See
+ * {@link TranslationEngine} for implementation details.
+ */
+public interface ITranslationEngine
+    extends FlowElement<ITranslationData, ElementPropertyMetaData> {
+
+    /**
+     * Element data key of the source flow element.
+     * @return source element data key
+     */
+    String getSourceElementDataKey();
+}

--- a/pipeline.translation/src/main/java/fiftyone/pipeline/translation/flowelements/TranslationEngine.java
+++ b/pipeline.translation/src/main/java/fiftyone/pipeline/translation/flowelements/TranslationEngine.java
@@ -1,0 +1,71 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+package fiftyone.pipeline.translation.flowelements;
+
+import fiftyone.pipeline.core.data.factories.ElementDataFactory;
+import fiftyone.pipeline.translation.data.ITranslationData;
+import fiftyone.pipeline.translation.data.MissingTranslationBehavior;
+import fiftyone.pipeline.translation.data.TranslationProperty;
+import org.slf4j.Logger;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Concrete translation engine. See {@link TranslationEngineBase} for
+ * implementation details.
+ */
+public class TranslationEngine
+    extends TranslationEngineBase<ITranslationData>
+    implements ITranslationEngine {
+
+    /**
+     * Create a new translation engine.
+     * @param sourceElementDataKey element data key of the source flow element
+     * @param translations the source -> destination property name pairs
+     * @param sources the YAML translation sources, keyed on file name
+     * @param fixedLanguage fixed language to translate to, or null to resolve
+     *                     from the evidence
+     * @param behavior the behaviour when a translation is missing for a value
+     * @param logger logger instance
+     * @param elementDataFactory factory used to create the element data
+     */
+    public TranslationEngine(
+        String sourceElementDataKey,
+        List<TranslationProperty> translations,
+        Map<String, String> sources,
+        String fixedLanguage,
+        MissingTranslationBehavior behavior,
+        Logger logger,
+        ElementDataFactory<ITranslationData> elementDataFactory) {
+        super(
+            sourceElementDataKey,
+            translations,
+            sources,
+            fixedLanguage,
+            behavior,
+            ITranslationData.class,
+            logger,
+            elementDataFactory);
+    }
+}

--- a/pipeline.translation/src/main/java/fiftyone/pipeline/translation/flowelements/TranslationEngineBase.java
+++ b/pipeline.translation/src/main/java/fiftyone/pipeline/translation/flowelements/TranslationEngineBase.java
@@ -1,0 +1,371 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+package fiftyone.pipeline.translation.flowelements;
+
+import fiftyone.pipeline.core.data.ElementData;
+import fiftyone.pipeline.core.data.ElementPropertyMetaData;
+import fiftyone.pipeline.core.data.ElementPropertyMetaDataDefault;
+import fiftyone.pipeline.core.data.Evidence;
+import fiftyone.pipeline.core.data.EvidenceKeyFilter;
+import fiftyone.pipeline.core.data.EvidenceKeyFilterWhitelist;
+import fiftyone.pipeline.core.data.FlowData;
+import fiftyone.pipeline.core.data.factories.ElementDataFactory;
+import fiftyone.pipeline.core.flowelements.FlowElementBase;
+import fiftyone.pipeline.core.typed.TypedKey;
+import fiftyone.pipeline.core.typed.TypedKeyDefault;
+import fiftyone.pipeline.engines.data.AspectPropertyValueDefault;
+import fiftyone.pipeline.translation.data.ITranslationData;
+import fiftyone.pipeline.translation.data.Languages;
+import fiftyone.pipeline.translation.data.MissingTranslationBehavior;
+import fiftyone.pipeline.translation.data.TranslationProperty;
+import fiftyone.pipeline.translation.data.Translator;
+import fiftyone.pipeline.translation.util.YamlTranslations;
+import org.slf4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Flow element that translates values from a single source element and stores
+ * translated values under its own element data key.
+ * <p>
+ * Translations are provided as YAML format files, where the file name defines
+ * the language contained in the file (e.g. {@code countries.fr_FR.yml}).
+ * <p>
+ * The language to translate to is determined by looking through the evidence
+ * for a key containing a locale code. The keys checked are, in order of
+ * precedence, {@code query.translation}, {@code query.accept-language} and
+ * {@code header.accept-language}. If a fixed language is supplied to the
+ * constructor, it is used instead, regardless of the evidence.
+ * <p>
+ * Only string based types are supported for translation (string, list of
+ * strings, weighted list of strings and the {@code AspectPropertyValue}
+ * wrappers); the output type matches the input.
+ *
+ * @param <T> the type of element data the engine writes
+ */
+public class TranslationEngineBase<T extends ITranslationData>
+    extends FlowElementBase<T, ElementPropertyMetaData> {
+
+    /**
+     * The keys, in order of precedence, used to get the locale code for the
+     * language to translate to.
+     */
+    private static final List<String> EVIDENCE_KEYS = Arrays.asList(
+        "query.translation",
+        "query.accept-language",
+        "header.accept-language");
+
+    /**
+     * Pattern used to identify locale codes (e.g. "en_GB") in file names and
+     * the fixed language.
+     */
+    private static final Pattern LOCALE_PATTERN =
+        Pattern.compile("[a-z]{2}_[A-Z]{2}");
+
+    /**
+     * Translator with no translations configured. Used to populate the output
+     * properties (with pass-through or no-value content) when there is no
+     * target language or translator available.
+     */
+    private final Translator emptyTranslator;
+
+    private final String fixedLanguage;
+    private final EvidenceKeyFilter evidenceKeyFilter;
+    private final String sourceElementDataKey;
+    private final MissingTranslationBehavior behavior;
+    private final List<TranslationProperty> translationProperties;
+    private final Languages languages;
+
+    /**
+     * The concrete element data type, used to build the typed data key. The
+     * generic {@link Class} cannot be recovered by reflection because
+     * {@link TranslationEngineBase} passes a type variable up to
+     * {@link FlowElementBase}, so it is supplied explicitly.
+     */
+    private final Class<T> dataType;
+
+    private List<ElementPropertyMetaData> properties;
+
+    /**
+     * Create a new translation engine.
+     * @param sourceElementDataKey element data key of the source flow element
+     * @param translations the translations to execute (source -> destination
+     *                     property name pairs)
+     * @param sources the YAML translation sources, keyed on file name
+     * @param fixedLanguage fixed language to translate to. If set, the engine
+     *                     always translates to this language; otherwise the
+     *                     language is taken from the evidence
+     * @param behavior the behaviour when a translation is missing for a value
+     * @param dataType the concrete element data type, used for the typed data
+     *                key
+     * @param logger logger instance
+     * @param elementDataFactory factory used to create the element data
+     */
+    public TranslationEngineBase(
+        String sourceElementDataKey,
+        List<TranslationProperty> translations,
+        Map<String, String> sources,
+        String fixedLanguage,
+        MissingTranslationBehavior behavior,
+        Class<T> dataType,
+        Logger logger,
+        ElementDataFactory<T> elementDataFactory) {
+        super(logger, elementDataFactory);
+        this.dataType = dataType;
+        if (translations == null || translations.isEmpty()) {
+            throw new IllegalArgumentException(
+                "At least one property translation must be configured.");
+        }
+        if (sources == null || sources.isEmpty()) {
+            throw new IllegalArgumentException(
+                "At least one source file must be configured.");
+        }
+        if (sourceElementDataKey == null ||
+            sourceElementDataKey.trim().isEmpty()) {
+            throw new IllegalArgumentException(
+                "The source element key must be configured.");
+        }
+
+        this.sourceElementDataKey = sourceElementDataKey.trim();
+        this.behavior = behavior;
+        this.emptyTranslator = new Translator(behavior);
+        this.fixedLanguage =
+            fixedLanguage != null ? validateLocale(fixedLanguage) : null;
+        this.languages = parseSources(sources, behavior);
+        this.evidenceKeyFilter = new EvidenceKeyFilterWhitelist(
+            EVIDENCE_KEYS, String.CASE_INSENSITIVE_ORDER);
+        this.translationProperties = new ArrayList<>(translations);
+    }
+
+    /**
+     * The translation sources used by this engine, keyed by locale.
+     * @return the {@link Languages} instance
+     */
+    protected Languages getLanguages() {
+        return languages;
+    }
+
+    @Override
+    public String getElementDataKey() {
+        return "translation";
+    }
+
+    @Override
+    public TypedKey<T> getTypedDataKey() {
+        if (typedKey == null) {
+            typedKey = new TypedKeyDefault<>(getElementDataKey(), dataType);
+        }
+        return typedKey;
+    }
+
+    /**
+     * Element data key of the source flow element.
+     * @return source element data key
+     */
+    public String getSourceElementDataKey() {
+        return sourceElementDataKey;
+    }
+
+    @Override
+    public EvidenceKeyFilter getEvidenceKeyFilter() {
+        return evidenceKeyFilter;
+    }
+
+    @Override
+    public List<ElementPropertyMetaData> getProperties() {
+        if (properties == null) {
+            List<ElementPropertyMetaData> result = new ArrayList<>();
+            Set<String> seen = new LinkedHashSet<>();
+            for (TranslationProperty translation : translationProperties) {
+                String name = translation.getDestinationProperty();
+                if (seen.add(name.toLowerCase())) {
+                    result.add(new ElementPropertyMetaDataDefault(
+                        name, this, "", Object.class, true));
+                }
+            }
+            properties = result;
+        }
+        return properties;
+    }
+
+    @Override
+    protected void processInternal(FlowData data) {
+        T translationData = data.getOrAdd(getTypedDataKey(), getDataFactory());
+
+        ElementData sourceData = data.get(sourceElementDataKey);
+        if (sourceData == null) {
+            data.addError(new NoSuchElementException("The source data '" +
+                sourceElementDataKey +
+                "' could not be found in the FlowData."), this);
+            return;
+        }
+
+        String language = getTargetLanguage(data);
+        if (language == null) {
+            if (behavior == MissingTranslationBehavior.FLOW_ERROR) {
+                data.addError(new NoSuchElementException("The evidence did " +
+                    "not contain a language to translate to."), this);
+            } else {
+                populate(sourceData, emptyTranslator, translationData, data);
+            }
+            return;
+        }
+
+        Translator translator = languages.getTranslator(language);
+        if (translator == null) {
+            if (behavior == MissingTranslationBehavior.FLOW_ERROR) {
+                data.addError(new NoSuchElementException("There was no " +
+                    "translator configured for the language '" +
+                    language + "'."), this);
+            } else {
+                populate(sourceData, emptyTranslator, translationData, data);
+            }
+            return;
+        }
+
+        populate(sourceData, translator, translationData, data);
+    }
+
+    /**
+     * Populate the translation data with every configured translation using
+     * the provided translator.
+     */
+    private void populate(
+        ElementData sourceData,
+        Translator translator,
+        T translationData,
+        FlowData data) {
+        for (TranslationProperty property : translationProperties) {
+            Object sourceValue = sourceData.get(property.getSourceProperty());
+            if (sourceValue == null) {
+                // The source type is unknown here, so use an
+                // AspectPropertyValue carrying a no-value message.
+                AspectPropertyValueDefault<String> value =
+                    new AspectPropertyValueDefault<>();
+                value.setNoValueMessage("The source property '" +
+                    property.getSourceProperty() +
+                    "' could not be found in the source data.");
+                translationData.put(property.getDestinationProperty(), value);
+            } else {
+                List<Exception> errors = new ArrayList<>();
+                translationData.put(
+                    property.getDestinationProperty(),
+                    translator.translate(sourceValue, errors));
+                for (Exception error : errors) {
+                    data.addError(error, this);
+                }
+            }
+        }
+    }
+
+    /**
+     * Get the highest precedence locale code from the evidence, or the fixed
+     * language if one was configured.
+     */
+    private String getTargetLanguage(FlowData data) {
+        if (fixedLanguage != null) {
+            return fixedLanguage;
+        }
+        if (data == null) {
+            return null;
+        }
+        Evidence evidence = data.getEvidence();
+        for (String key : EVIDENCE_KEYS) {
+            Object value = evidence.get(key);
+            if (value instanceof String &&
+                ((String) value).trim().isEmpty() == false) {
+                return (String) value;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    protected void managedResourcesCleanup() {
+    }
+
+    @Override
+    protected void unmanagedResourcesCleanup() {
+    }
+
+    /**
+     * Parse the source files into a {@link Languages} instance containing a
+     * {@link Translator} for each file.
+     */
+    private static Languages parseSources(
+        Map<String, String> sources,
+        MissingTranslationBehavior behavior) {
+        Languages languages = new Languages();
+        for (Map.Entry<String, String> source : sources.entrySet()) {
+            String language = getLanguageName(source.getKey());
+            Map<String, String> translations =
+                YamlTranslations.parse(source.getValue());
+            languages.addLanguage(
+                language, new Translator(translations, behavior));
+        }
+        return languages;
+    }
+
+    /**
+     * Get the locale code from a source file name following the
+     * {@code name.locale.yml} convention (e.g. "countries.fr_FR.yml").
+     */
+    private static String getLanguageName(String name) {
+        if (name == null || name.trim().isEmpty()) {
+            throw new IllegalArgumentException(
+                "Source name cannot be null or whitespace.");
+        }
+        String[] parts = name.split("\\.");
+        if (parts.length < 3) {
+            throw new IllegalArgumentException("Source name '" + name +
+                "' does not have the correct format. It should be " +
+                "'somename.locale.yml' e.g. 'countries.en_GB.yml'.");
+        }
+        String locale = validateLocale(parts[parts.length - 2]);
+        if (locale == null) {
+            throw new IllegalArgumentException("Source name '" + name +
+                "' does not contain a valid locale code.");
+        }
+        return locale;
+    }
+
+    /**
+     * Return the validated locale code found within the supplied value, or
+     * null if none is present.
+     */
+    private static String validateLocale(String locale) {
+        if (locale == null) {
+            return null;
+        }
+        Matcher matcher = LOCALE_PATTERN.matcher(locale);
+        return matcher.find() ? matcher.group() : null;
+    }
+}

--- a/pipeline.translation/src/main/java/fiftyone/pipeline/translation/flowelements/TranslationEngineBuilder.java
+++ b/pipeline.translation/src/main/java/fiftyone/pipeline/translation/flowelements/TranslationEngineBuilder.java
@@ -1,0 +1,160 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+package fiftyone.pipeline.translation.flowelements;
+
+import fiftyone.pipeline.translation.data.MissingTranslationBehavior;
+import fiftyone.pipeline.translation.data.TranslationData;
+import fiftyone.pipeline.translation.data.TranslationProperty;
+import org.slf4j.ILoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Fluent builder for {@link TranslationEngine}.
+ */
+public class TranslationEngineBuilder {
+
+    private final ILoggerFactory loggerFactory;
+    private final List<TranslationProperty> translationProperties =
+        new ArrayList<>();
+    private final Map<String, String> sources = new LinkedHashMap<>();
+    private String sourceElementDataKey;
+    private String fixedLanguage = null;
+    private MissingTranslationBehavior behavior =
+        MissingTranslationBehavior.ORIGINAL;
+
+    /**
+     * Construct a new builder.
+     * @param loggerFactory the logger factory to use for the engine and the
+     *                     element data it creates
+     */
+    public TranslationEngineBuilder(ILoggerFactory loggerFactory) {
+        if (loggerFactory == null) {
+            throw new IllegalArgumentException("loggerFactory");
+        }
+        this.loggerFactory = loggerFactory;
+    }
+
+    /**
+     * Set the element data key of the source element the engine reads from.
+     * @param sourceElementDataKey the source element data key
+     * @return this builder
+     */
+    public TranslationEngineBuilder setSourceElementDataKey(
+        String sourceElementDataKey) {
+        this.sourceElementDataKey = sourceElementDataKey;
+        return this;
+    }
+
+    /**
+     * Set a fixed language for the engine to translate to. If set, the engine
+     * always translates to this language instead of resolving it from the
+     * evidence.
+     * @param language the language to translate to
+     * @return this builder
+     */
+    public TranslationEngineBuilder setFixedLanguage(String language) {
+        this.fixedLanguage = language;
+        return this;
+    }
+
+    /**
+     * Set the behaviour when a translation is missing for a value.
+     * @param behavior the missing-translation behaviour
+     * @return this builder
+     */
+    public TranslationEngineBuilder setMissingTranslationBehavior(
+        MissingTranslationBehavior behavior) {
+        this.behavior = behavior;
+        return this;
+    }
+
+    /**
+     * Add a translation from a source property to a destination property.
+     * @param source the source property key to translate
+     * @param destination the destination property key to store the translated
+     *                   value under on the engine data
+     * @return this builder
+     */
+    public TranslationEngineBuilder addTranslation(
+        String source,
+        String destination) {
+        if (source == null || destination == null) {
+            throw new IllegalArgumentException(
+                "Source and destination must not be null.");
+        }
+        translationProperties.add(
+            new TranslationProperty(source, destination));
+        return this;
+    }
+
+    /**
+     * Add a translation source by name and content. The name follows the
+     * {@code abc.en_GB.yml} convention, where the locale code determines the
+     * language contained in the file.
+     * @param name the file name
+     * @param source the file contents (YAML)
+     * @return this builder
+     */
+    public TranslationEngineBuilder addSource(String name, String source) {
+        sources.put(name, source);
+        return this;
+    }
+
+    /**
+     * Add a translation source by reading the supplied file as UTF-8. The file
+     * name follows the {@code abc.en_GB.yml} convention.
+     * @param file the source file
+     * @return this builder
+     * @throws IOException if the file cannot be read
+     */
+    public TranslationEngineBuilder addSource(File file) throws IOException {
+        byte[] content = Files.readAllBytes(file.toPath());
+        return addSource(
+            file.getName(), new String(content, StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Build a translation engine.
+     * @return a new {@link TranslationEngine}
+     */
+    public TranslationEngine build() {
+        return new TranslationEngine(
+            sourceElementDataKey,
+            translationProperties,
+            sources,
+            fixedLanguage,
+            behavior,
+            loggerFactory.getLogger(TranslationEngine.class.getName()),
+            (flowData, flowElement) -> new TranslationData(
+                loggerFactory.getLogger(TranslationData.class.getName()),
+                flowData));
+    }
+}

--- a/pipeline.translation/src/main/java/fiftyone/pipeline/translation/flowelements/TranslationEngineBuilder.java
+++ b/pipeline.translation/src/main/java/fiftyone/pipeline/translation/flowelements/TranslationEngineBuilder.java
@@ -30,7 +30,10 @@ import org.slf4j.ILoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -129,16 +132,40 @@ public class TranslationEngineBuilder {
     }
 
     /**
-     * Add a translation source by reading the supplied file as UTF-8. The file
-     * name follows the {@code abc.en_GB.yml} convention.
-     * @param file the source file
+     * Add one or more translation sources by reading them from disk as UTF-8.
+     * The path may contain a wildcard in the file name to add multiple files,
+     * e.g. {@code abc.*.yml} to add all languages for the {@code abc}
+     * identifier. File names follow the {@code abc.en_GB.yml} convention.
+     * @param filePath the path to the source file, where a wildcard may be
+     *                used for the language component of the file name
      * @return this builder
-     * @throws IOException if the file cannot be read
+     * @throws IOException if a file cannot be read
      */
-    public TranslationEngineBuilder addSource(File file) throws IOException {
-        byte[] content = Files.readAllBytes(file.toPath());
-        return addSource(
-            file.getName(), new String(content, StandardCharsets.UTF_8));
+    public TranslationEngineBuilder addSource(String filePath)
+        throws IOException {
+        if (filePath == null) {
+            throw new IllegalArgumentException("filePath");
+        }
+        if (filePath.contains("*")) {
+            File file = new File(filePath);
+            File parent = file.getParentFile();
+            Path directory = (parent != null ? parent : new File(".")).toPath();
+            try (DirectoryStream<Path> stream =
+                Files.newDirectoryStream(directory, file.getName())) {
+                for (Path match : stream) {
+                    addSource(match.getFileName().toString(), readUtf8(match));
+                }
+            }
+        } else {
+            Path path = Paths.get(filePath);
+            addSource(path.getFileName().toString(), readUtf8(path));
+        }
+        return this;
+    }
+
+    private static String readUtf8(Path path) throws IOException {
+        return new String(
+            Files.readAllBytes(path), StandardCharsets.UTF_8);
     }
 
     /**

--- a/pipeline.translation/src/main/java/fiftyone/pipeline/translation/util/YamlTranslations.java
+++ b/pipeline.translation/src/main/java/fiftyone/pipeline/translation/util/YamlTranslations.java
@@ -1,0 +1,86 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+package fiftyone.pipeline.translation.util;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Minimal parser for the flat <code>key: value</code> YAML maps used by the
+ * translation files (e.g. <code>countrycodes.en_GB.yml</code>,
+ * <code>countries.fr_FR.yml</code>). These files contain a single mapping of
+ * scalar string to scalar string with no nesting, anchors, flow collections or
+ * quoting, so a full YAML parser is not required.
+ * <p>
+ * The returned map preserves the order in which entries appear in the file,
+ * which the country engine relies on for the ordered list of all known
+ * countries.
+ */
+public class YamlTranslations {
+
+    /**
+     * Unicode byte order mark (U+FEFF), stripped from the start of a file if
+     * present.
+     */
+    private static final int BOM = 0xFEFF;
+
+    private YamlTranslations() {
+    }
+
+    /**
+     * Parse a flat <code>key: value</code> YAML document into an insertion
+     * ordered map. Blank lines and lines beginning with <code>#</code> are
+     * ignored, as are lines that contain no <code>:</code> separator. Keys and
+     * values are trimmed. The first <code>:</code> on a line is treated as the
+     * separator.
+     * @param yaml the YAML document contents, or null
+     * @return an ordered map of the parsed entries (never null)
+     */
+    public static Map<String, String> parse(String yaml) {
+        Map<String, String> result = new LinkedHashMap<>();
+        if (yaml == null || yaml.isEmpty()) {
+            return result;
+        }
+        if (yaml.charAt(0) == BOM) {
+            yaml = yaml.substring(1);
+        }
+        for (String rawLine : yaml.split("\n", -1)) {
+            // Tolerate Windows line endings and surrounding whitespace.
+            String line = rawLine.trim();
+            if (line.isEmpty() || line.charAt(0) == '#') {
+                continue;
+            }
+            int separator = line.indexOf(':');
+            if (separator < 0) {
+                continue;
+            }
+            String key = line.substring(0, separator).trim();
+            String value = line.substring(separator + 1).trim();
+            if (key.isEmpty()) {
+                continue;
+            }
+            result.put(key, value);
+        }
+        return result;
+    }
+}

--- a/pipeline.translation/src/main/java/fiftyone/pipeline/translation/util/YamlTranslations.java
+++ b/pipeline.translation/src/main/java/fiftyone/pipeline/translation/util/YamlTranslations.java
@@ -22,37 +22,31 @@
 
 package fiftyone.pipeline.translation.util;
 
+import org.snakeyaml.engine.v2.api.Load;
+import org.snakeyaml.engine.v2.api.LoadSettings;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * Minimal parser for the flat <code>key: value</code> YAML maps used by the
- * translation files (e.g. <code>countrycodes.en_GB.yml</code>,
- * <code>countries.fr_FR.yml</code>). These files contain a single mapping of
- * scalar string to scalar string with no nesting, anchors, flow collections or
- * quoting, so a full YAML parser is not required.
+ * Parses the flat <code>key: value</code> YAML maps used by the translation
+ * files (e.g. <code>countrycodes.en_GB.yml</code>,
+ * <code>countries.fr_FR.yml</code>) into an insertion-ordered map.
  * <p>
- * The returned map preserves the order in which entries appear in the file,
- * which the country engine relies on for the ordered list of all known
- * countries.
+ * Uses snakeyaml-engine (YAML 1.2). YAML 1.2 is important here: the country
+ * code file contains the key <code>NO</code> (Norway), which YAML 1.1 parsers
+ * (including the classic snakeyaml library) would resolve to the boolean
+ * <code>false</code>. Under YAML 1.2 it correctly remains the string
+ * "NO".
  */
 public class YamlTranslations {
-
-    /**
-     * Unicode byte order mark (U+FEFF), stripped from the start of a file if
-     * present.
-     */
-    private static final int BOM = 0xFEFF;
 
     private YamlTranslations() {
     }
 
     /**
      * Parse a flat <code>key: value</code> YAML document into an insertion
-     * ordered map. Blank lines and lines beginning with <code>#</code> are
-     * ignored, as are lines that contain no <code>:</code> separator. Keys and
-     * values are trimmed. The first <code>:</code> on a line is treated as the
-     * separator.
+     * ordered map. Keys and values are returned as strings.
      * @param yaml the YAML document contents, or null
      * @return an ordered map of the parsed entries (never null)
      */
@@ -61,25 +55,19 @@ public class YamlTranslations {
         if (yaml == null || yaml.isEmpty()) {
             return result;
         }
-        if (yaml.charAt(0) == BOM) {
-            yaml = yaml.substring(1);
-        }
-        for (String rawLine : yaml.split("\n", -1)) {
-            // Tolerate Windows line endings and surrounding whitespace.
-            String line = rawLine.trim();
-            if (line.isEmpty() || line.charAt(0) == '#') {
-                continue;
+        LoadSettings settings = LoadSettings.builder().build();
+        Object loaded = new Load(settings).loadFromString(yaml);
+        if (loaded instanceof Map) {
+            for (Map.Entry<?, ?> entry : ((Map<?, ?>) loaded).entrySet()) {
+                if (entry.getKey() == null) {
+                    continue;
+                }
+                String key = entry.getKey().toString();
+                String value = entry.getValue() == null
+                    ? ""
+                    : entry.getValue().toString();
+                result.put(key, value);
             }
-            int separator = line.indexOf(':');
-            if (separator < 0) {
-                continue;
-            }
-            String key = line.substring(0, separator).trim();
-            String value = line.substring(separator + 1).trim();
-            if (key.isEmpty()) {
-                continue;
-            }
-            result.put(key, value);
         }
         return result;
     }

--- a/pipeline.translation/src/test/java/fiftyone/pipeline/translation/data/LanguagesTests.java
+++ b/pipeline.translation/src/test/java/fiftyone/pipeline/translation/data/LanguagesTests.java
@@ -1,0 +1,103 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+package fiftyone.pipeline.translation.data;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class LanguagesTests {
+
+    private static final List<String> AVAILABLE =
+        Arrays.asList("de_DE", "es_ES", "fr_FR", "it_IT");
+
+    @Test
+    public void parseOrdersByQualityDescending() {
+        List<String> parsed =
+            Languages.parseAcceptLanguage("es,de-DE;q=0.8,en;q=0.5");
+        assertEquals(Arrays.asList("es", "de_DE", "en"), parsed);
+    }
+
+    @Test
+    public void parseNormalisesDashToUnderscore() {
+        List<String> parsed = Languages.parseAcceptLanguage("fr-FR");
+        assertEquals(Arrays.asList("fr_FR"), parsed);
+    }
+
+    @Test
+    public void resolvesExactMatch() {
+        assertEquals("fr_FR",
+            Languages.resolveLocale("fr_FR", AVAILABLE, "en"));
+    }
+
+    @Test
+    public void resolvesTwoLetterFallback() {
+        assertEquals("fr_FR",
+            Languages.resolveLocale("fr", AVAILABLE, "en"));
+    }
+
+    @Test
+    public void dashResolvesSameAsUnderscore() {
+        assertEquals("fr_FR",
+            Languages.resolveLocale("fr-FR", AVAILABLE, "en"));
+    }
+
+    @Test
+    public void englishShortCircuitsToNoMatch() {
+        assertNull(Languages.resolveLocale(
+            "en-GB,fr;q=0.5", AVAILABLE, "en"));
+    }
+
+    @Test
+    public void englishPreferredOverLowerPriorityLanguage() {
+        assertNull(Languages.resolveLocale(
+            "en-US,en;q=0.9,de-DE;q=0.5", AVAILABLE, "en"));
+    }
+
+    @Test
+    public void higherPriorityLanguageMatchedFirst() {
+        assertEquals("es_ES", Languages.resolveLocale(
+            "es,de-DE;q=0.8,fr;q=0.5", AVAILABLE, "en"));
+    }
+
+    @Test
+    public void matchReturnsTranslatorAndLocale() {
+        Languages languages = new Languages();
+        languages.addLanguage("fr_FR",
+            new Translator(MissingTranslationBehavior.ORIGINAL));
+        Languages.Match match = languages.match("fr-FR");
+        assertEquals("fr_FR", match.getLocale());
+    }
+
+    @Test
+    public void noMatchReturnsNull() {
+        Languages languages = new Languages();
+        languages.addLanguage("fr_FR",
+            new Translator(MissingTranslationBehavior.ORIGINAL));
+        assertNull(languages.match("zz-ZZ"));
+    }
+}

--- a/pipeline.translation/src/test/java/fiftyone/pipeline/translation/data/TranslatorTests.java
+++ b/pipeline.translation/src/test/java/fiftyone/pipeline/translation/data/TranslatorTests.java
@@ -1,0 +1,142 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+package fiftyone.pipeline.translation.data;
+
+import fiftyone.pipeline.core.data.IWeightedValue;
+import fiftyone.pipeline.core.data.WeightedValue;
+import fiftyone.pipeline.engines.data.AspectPropertyValue;
+import fiftyone.pipeline.engines.data.AspectPropertyValueDefault;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TranslatorTests {
+
+    private static Map<String, String> map() {
+        Map<String, String> m = new HashMap<>();
+        m.put("France", "La France");
+        m.put("Germany", "Allemagne");
+        return m;
+    }
+
+    @Test
+    public void translatesString() {
+        Translator translator =
+            new Translator(map(), MissingTranslationBehavior.ORIGINAL);
+        assertEquals("La France",
+            translator.translate("France", new ArrayList<>()));
+    }
+
+    @Test
+    public void lookupIsCaseInsensitive() {
+        Translator translator =
+            new Translator(map(), MissingTranslationBehavior.ORIGINAL);
+        assertEquals("La France",
+            translator.translate("france", new ArrayList<>()));
+    }
+
+    @Test
+    public void missingValueOriginal() {
+        Translator translator =
+            new Translator(map(), MissingTranslationBehavior.ORIGINAL);
+        assertEquals("Spain",
+            translator.translate("Spain", new ArrayList<>()));
+    }
+
+    @Test
+    public void missingValueEmptyString() {
+        Translator translator =
+            new Translator(map(), MissingTranslationBehavior.EMPTY_STRING);
+        assertEquals("",
+            translator.translate("Spain", new ArrayList<>()));
+    }
+
+    @Test
+    public void missingValueFlowError() {
+        Translator translator =
+            new Translator(map(), MissingTranslationBehavior.FLOW_ERROR);
+        List<Exception> errors = new ArrayList<>();
+        Object result = translator.translate("Spain", errors);
+        assertNull(result);
+        assertEquals(1, errors.size());
+    }
+
+    @Test
+    public void translatesPlainStringList() {
+        Translator translator =
+            new Translator(map(), MissingTranslationBehavior.ORIGINAL);
+        @SuppressWarnings("unchecked")
+        List<String> result = (List<String>) translator.translate(
+            Arrays.asList("France", "Germany", "Spain"), new ArrayList<>());
+        assertEquals(Arrays.asList("La France", "Allemagne", "Spain"), result);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void translatesWeightedListPreservingWeights() {
+        Translator translator =
+            new Translator(map(), MissingTranslationBehavior.ORIGINAL);
+
+        List<IWeightedValue<String>> input = new ArrayList<>();
+        input.add(new WeightedValue<>(30000, "France"));
+        input.add(new WeightedValue<>(35535, "Germany"));
+        AspectPropertyValue<List<IWeightedValue<String>>> wrapped =
+            new AspectPropertyValueDefault<>(input);
+
+        AspectPropertyValue<List<IWeightedValue<String>>> result =
+            (AspectPropertyValue<List<IWeightedValue<String>>>)
+                translator.translate(wrapped, new ArrayList<>());
+
+        assertTrue(result.hasValue());
+        List<IWeightedValue<String>> values = result.getValue();
+        assertEquals("La France", values.get(0).getValue());
+        assertEquals(30000, values.get(0).getRawWeighting());
+        assertEquals("Allemagne", values.get(1).getValue());
+        assertEquals(35535, values.get(1).getRawWeighting());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void copiesNoValueMessage() {
+        Translator translator =
+            new Translator(map(), MissingTranslationBehavior.ORIGINAL);
+        AspectPropertyValueDefault<List<IWeightedValue<String>>> empty =
+            new AspectPropertyValueDefault<>();
+        empty.setNoValueMessage("nothing here");
+
+        AspectPropertyValue<List<IWeightedValue<String>>> result =
+            (AspectPropertyValue<List<IWeightedValue<String>>>)
+                translator.translate(empty, new ArrayList<>());
+
+        assertEquals(false, result.hasValue());
+        assertEquals("nothing here", result.getNoValueMessage());
+    }
+}

--- a/pipeline.translation/src/test/java/fiftyone/pipeline/translation/util/YamlTranslationsTests.java
+++ b/pipeline.translation/src/test/java/fiftyone/pipeline/translation/util/YamlTranslationsTests.java
@@ -59,12 +59,14 @@ public class YamlTranslationsTests {
     }
 
     @Test
-    public void splitsOnFirstColonOnly() {
-        // Keys with no colon; values never contain a colon in the data, but
-        // ensure only the first separator is used.
-        String yaml = "Name: Value: With Colon\n";
+    public void keepsNoAsStringNotBoolean() {
+        // The country code file contains "NO" (Norway). A YAML 1.1 parser
+        // would resolve it to the boolean false; YAML 1.2 keeps it a string.
+        String yaml = "FR: France\nNO: Norway\n";
         Map<String, String> result = YamlTranslations.parse(yaml);
-        assertEquals("Value: With Colon", result.get("Name"));
+        assertEquals("Norway", result.get("NO"));
+        assertEquals(Arrays.asList("FR", "NO"),
+            new ArrayList<>(result.keySet()));
     }
 
     @Test

--- a/pipeline.translation/src/test/java/fiftyone/pipeline/translation/util/YamlTranslationsTests.java
+++ b/pipeline.translation/src/test/java/fiftyone/pipeline/translation/util/YamlTranslationsTests.java
@@ -1,0 +1,77 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+package fiftyone.pipeline.translation.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class YamlTranslationsTests {
+
+    @Test
+    public void parsesFlatMapPreservingOrder() {
+        String yaml = "AD: Andorra\nAE: United Arab Emirates\nAF: Afghanistan\n";
+        Map<String, String> result = YamlTranslations.parse(yaml);
+        assertEquals(Arrays.asList("AD", "AE", "AF"),
+            new ArrayList<>(result.keySet()));
+        assertEquals("United Arab Emirates", result.get("AE"));
+    }
+
+    @Test
+    public void skipsBlankAndCommentLines() {
+        String yaml = "# comment\n\nAD: Andorra\n\n# another\nAE: Emirates\n";
+        Map<String, String> result = YamlTranslations.parse(yaml);
+        assertEquals(2, result.size());
+        assertEquals("Andorra", result.get("AD"));
+    }
+
+    @Test
+    public void preservesUnicodeValues() {
+        String yaml = "Algeria: Algérie\nUkraine: Україна\n";
+        Map<String, String> result = YamlTranslations.parse(yaml);
+        assertEquals("Algérie", result.get("Algeria"));
+        assertEquals("Україна",
+            result.get("Ukraine"));
+    }
+
+    @Test
+    public void splitsOnFirstColonOnly() {
+        // Keys with no colon; values never contain a colon in the data, but
+        // ensure only the first separator is used.
+        String yaml = "Name: Value: With Colon\n";
+        Map<String, String> result = YamlTranslations.parse(yaml);
+        assertEquals("Value: With Colon", result.get("Name"));
+    }
+
+    @Test
+    public void toleratesCarriageReturns() {
+        String yaml = "AD: Andorra\r\nAE: Emirates\r\n";
+        Map<String, String> result = YamlTranslations.parse(yaml);
+        assertEquals("Andorra", result.get("AD"));
+        assertEquals("Emirates", result.get("AE"));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
         <module>pipeline.caching</module>
         <module>pipeline.cloudrequestengine</module>
         <module>pipeline.engines.fiftyone</module>
+        <module>pipeline.translation</module>
         <module>pipeline.javascriptbuilder</module>
         <module>pipeline.jsonbuilder</module>
         <module>pipeline.web.packages</module>


### PR DESCRIPTION
# Add a generic translation flow element (pipeline.translation)

## Background
On-premise IP Intelligence returns country information as weighted lists of
ISO country codes. To turn those into localized, ordered country names for the
demos, a generic translation flow element is needed. This mirrors the .NET
layout, where the generic translation logic lives in the pipeline repo
(`FiftyOne.Pipeline.Translation`) and the IP Intelligence country engines build
on top of it. The matching IP Intelligence engines are added in
`ip-intelligence-java` and depend on this module.

## Objectives
- Provide a reusable translation flow element that translates string based
  property values from one element to another, preserving the shape of the
  value (string, list of strings, weighted list of strings and their
  `AspectPropertyValue` wrappers).
- Resolve the target language from a fixed language or from the evidence, with
  the same precedence and locale matching rules as the .NET implementation.
- Add no third party dependencies.

## Key Decisions
- New module `pipeline.translation` (`com.51degrees:pipeline.translation`),
  depending only on the existing `pipeline.core` and `pipeline.engines`.
- `TranslationEngineBase` extends `FlowElementBase` (no aspect-engine caching
  is needed). Because the base is generic and passes a type variable up to
  `FlowElementBase`, `Types.findSubClassParameterType` cannot recover the
  concrete data type by reflection, so the concrete element data `Class<T>` is
  passed to the constructor and used to build the typed data key.
- YAML is parsed with **snakeyaml-engine** (YAML 1.2). This is deliberate over
  the classic snakeyaml library, which is YAML 1.1 and would resolve the
  country code `NO` (Norway) to the boolean `false`. snakeyaml-engine keeps it
  the string "NO", is actively maintained, and has none of the classic
  snakeyaml CVEs.
- `Languages` parses Accept-Language with a stable quality sort so equal
  quality tags keep their input order, implements the English short circuit
  (English is the base language, so it yields no translator) and the two letter
  language fallback (for example `fr` matches `fr_FR`).

## Changes
- New `pipeline.translation` module:
  - `data`: `MissingTranslationBehavior`, `TranslationProperty`, `Translator`
    (weighted-list translation keeping `getRawWeighting()` unchanged),
    `Languages`, `ITranslationData`, `TranslationData`.
  - `flowelements`: `TranslationEngineBase`, `TranslationEngine`,
    `ITranslationEngine`, `TranslationEngineBuilder`.
  - `util`: `YamlTranslations` (order-preserving YAML map parser, on
    snakeyaml-engine).
- `TranslationEngineBuilder.addSource(String filePath)` supports a wildcard in
  the file name (for example `abc.*.yml`) for parity with the .NET builder.
- `pom.xml`: register the new module in `<modules>`; add the snakeyaml-engine
  dependency.

## Testing
`mvn -pl pipeline.translation -am test` (JDK 25, source/target 1.8), 23 tests,
all passing, `-Werror` clean:
- `TranslatorTests` (8): string, list and weighted-list translation, weight
  preservation, the three missing-translation behaviours, case-insensitive
  lookup, no-value message copying.
- `LanguagesTests` (10): Accept-Language parsing and quality ordering, exact
  and two letter locale resolution, English short circuit, dash normalisation.
- `YamlTranslationsTests` (5): order preserved, comments and blank lines
  skipped, UTF-8 values, carriage returns, first-colon split.

## Notes
- Additive only. One new module plus one line in the parent pom `<modules>`. No
  existing modules change. One new third party dependency, snakeyaml-engine.
- Release coordination: `ip-intelligence-java` consumes this module at the
  published pipeline version, so it must be released in the pipeline line that
  `ip-intelligence-java` targets, and this change should merge first. See the
  `ip-intelligence-java` PR for details of the local bridge used for
  development.
