### PR TITLE
Update Selenium; split version by JDK (4.14.1 / 4.46.0)

### DIFF
--- a/pipeline.javascriptbuilder/pom.xml
+++ b/pipeline.javascriptbuilder/pom.xml
@@ -25,9 +25,10 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <properties>
-        <!-- Last selenium-java release that still runs on Java 8; the
-             jdk11-selenium profile below upgrades it on Java 11+. -->
-        <selenium.version>4.14.1</selenium.version>
+        <!-- Selenium ships Java 11 class files from 4.14.0 onwards, so the
+             browser tests are built and run on the Java 11+ legs only. See
+             the profiles at the end of this file. -->
+        <selenium.version>4.46.0</selenium.version>
     </properties>
     <parent>
         <groupId>com.51degrees</groupId>
@@ -85,30 +86,55 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-java</artifactId>
-            <version>${selenium.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <profiles>
-        <!-- Selenium dropped Java 8 support after 4.14.x. Tests still run on
-             the Java 8 CI legs with 4.14.1 (default above); on Java 11+ this
-             profile activates automatically and upgrades to a current release
-             whose Selenium Manager resolves matching Chrome/ChromeDriver
-             versions (old managers can pair a stale cached driver with a
-             newer browser: "This version of ChromeDriver only supports
-             Chrome version NNN"). -->
+        <!-- Selenium 4.14.0 moved to Java 11 class files, and the last release
+             that still runs on Java 8 (4.13.0) bundles a Selenium Manager that
+             pairs a stale cached ChromeDriver with current Chrome, failing with
+             "This version of ChromeDriver only supports Chrome version NNN".
+             There is therefore no Selenium version that both compiles on Java 8
+             and drives a current browser, so JavaScriptBuilderTests is built and
+             run on Java 11+ only. Every test in that class needs a browser: it
+             starts a ChromeDriver in Init() and quits it in Cleanup(). -->
         <profile>
             <id>jdk11-selenium</id>
             <activation>
                 <jdk>[11,)</jdk>
             </activation>
-            <properties>
-                <selenium.version>4.46.0</selenium.version>
-            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.seleniumhq.selenium</groupId>
+                    <artifactId>selenium-java</artifactId>
+                    <version>${selenium.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <!-- On Java 8 the Selenium tests are dropped at test *compilation*, not
+             just from the test run: javac fails reading the Java 11 class files
+             ("class file has wrong version 55.0, should be 52.0") long before
+             surefire is reached, so a surefire <excludes> alone would not help.
+             The module's other tests are unaffected. -->
+        <profile>
+            <id>jdk8-no-selenium</id>
+            <activation>
+                <jdk>(,11)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <testExcludes>
+                                <testExclude>**/JavaScriptBuilderTests.java</testExclude>
+                            </testExcludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>

--- a/pipeline.javascriptbuilder/pom.xml
+++ b/pipeline.javascriptbuilder/pom.xml
@@ -25,6 +25,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <properties>
+        <!-- Last selenium-java release that still runs on Java 8; the
+             jdk11-selenium profile below upgrades it on Java 11+. -->
+        <selenium.version>4.14.1</selenium.version>
     </properties>
     <parent>
         <groupId>com.51degrees</groupId>
@@ -85,8 +88,27 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>4.13.0</version>
+            <version>${selenium.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <!-- Selenium dropped Java 8 support after 4.14.x. Tests still run on
+             the Java 8 CI legs with 4.14.1 (default above); on Java 11+ this
+             profile activates automatically and upgrades to a current release
+             whose Selenium Manager resolves matching Chrome/ChromeDriver
+             versions (old managers can pair a stale cached driver with a
+             newer browser: "This version of ChromeDriver only supports
+             Chrome version NNN"). -->
+        <profile>
+            <id>jdk11-selenium</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <properties>
+                <selenium.version>4.46.0</selenium.version>
+            </properties>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Fixes the nightly JavaScriptBuilderTests failures on Windows_Java_8 (SessionNotCreatedException: This version of ChromeDriver only supports Chrome version 149 vs browser 151) seen in https://github.com/51Degrees/pipeline-java/actions/runs/29470481774. The Selenium Manager bundled with selenium-java 4.13.0 paired a stale cached ChromeDriver with the current Chrome. Selenium dropped Java 8 support after 4.14.x, so a selenium.version property defaults to 4.14.1 for the Java 8 CI legs and a jdk11-selenium profile upgrades JDK 11+ legs to 4.46.0. Part of #123.