### PR TITLE
FIX: Cast 0xFF to byte to satisfy JDK 21 lossy-conversions lint

### DIFF
--- a/pipeline.did/src/test/java/fiftyone/pipeline/did/FodIdTests.java
+++ b/pipeline.did/src/test/java/fiftyone/pipeline/did/FodIdTests.java
@@ -365,7 +365,7 @@ public class FodIdTests {
         // verify.
         byte[] bytes = Base64.getDecoder().decode(
             factory.signedOwidBase64(canonicalPayload()));
-        bytes[bytes.length - 1] ^= 0xFF;   // corrupt the signature
+        bytes[bytes.length - 1] ^= (byte) 0xFF;   // corrupt the signature
         Owid tampered = Owid.fromByteArray(bytes);
 
         FodId fodId = FodId.fromOwid(tampered);


### PR DESCRIPTION
`FodIdTests.construction_DoesNotVerify` corrupts the trailing signature byte
with a compound assignment:

```java
bytes[bytes.length - 1] ^= 0xFF;
```

`0xFF` is an `int`, so `byte ^= int` narrows implicitly. JDK 21 added
`-Xlint:lossy-conversions`, which flags exactly this, and the build already
passes `-Xlint:all`. The cast makes the existing narrowing explicit:

```java
bytes[bytes.length - 1] ^= (byte) 0xFF;
```

Behaviour is unchanged — the value was already being truncated to a `byte`, it
just was not spelled out.

## Why now

`main` builds green today because `-Werror` is commented out in `pom.xml`, so
the warning is only advisory. PR #99 turns `-Werror` back on, at which point
this warning becomes a hard build failure on the Java 21 legs — which is what
happened on the nightly run:

```
[WARNING] FodIdTests.java:[368,36] implicit cast from int to byte in compound assignment is possibly lossy
[ERROR]   FodIdTests.java: warnings found and -Werror specified
[ERROR] Failed to execute goal ...maven-compiler-plugin:3.9.0:testCompile on project pipeline.did
```

PR #99 predates the `pipeline.did` module, so its warning sweep never saw this
file. Landing the fix here on `main` means #99 picks it up through the nightly
merge-with-main build without needing changes to that branch.

Only Java 21 is affected — `lossy-conversions` does not exist before JDK 21,
which is why the 8/11/17 legs compiled the full reactor while 21 failed at
`pipeline.did`.

## Verification

- Swept every `*.java` in the repo for compound assignments on narrow-typed
  targets; this was the only one. The rest are `String +=` or `int += int`.
- Compiled the corrected expression under `-Xlint:all,-try,-options -Werror`
  and confirmed the result is identical.

Verified locally on JDK 17 only — `-Xlint:lossy-conversions` does not exist
before JDK 21, so CI is the confirmation for the lint itself.

Relates to #TASK
